### PR TITLE
Use oldest N-API version possible

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,7 @@
   "targets": [
     {
       "target_name": "watcher",
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS", "NAPI_VERSION=1" ],
       "sources": [ "src/binding.cc", "src/Watcher.cc", "src/Backend.cc", "src/DirTree.cc" ],
       "include_dirs" : ["<!@(node -p \"require('node-addon-api').include\")"],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "binary": {
     "napi_versions": [
-      3
+      1
     ]
   }
 }


### PR DESCRIPTION
We don't seem to use any "modern" features anyway.