### PR TITLE
Use MakeCallback instead of Call

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -28,16 +28,16 @@ jobs:
 
   - ${{ if eq(parameters.name, 'Windows') }}:
     - script: |
-        curl -sSf -L -o watchman.zip https://ci.appveyor.com/api/buildjobs/vkp4mmk1cri9jsel/artifacts/watchman.zip
+        curl -sSf -L -o watchman.zip https://github.com/facebook/watchman/suites/296618337/artifacts/249606
       displayName: Download Watchman
     - task: ExtractFiles@1
       inputs:
         archiveFilePatterns: 'watchman.zip'
-        destinationFolder: $(Agent.HomeDirectory)\watchman
+        destinationFolder: $(Agent.HomeDirectory)
         cleanDestinationFolder: false
       displayName: Extract Watchman
     - script: |
-        set PATH=%PATH%;$(Agent.HomeDirectory)\watchman
+        set PATH=%PATH%;$(Agent.HomeDirectory)\watchman\windows\bin
         echo "##vso[task.setvariable variable=PATH]%PATH%"
         watchman -v
       displayName: Install Watchman

--- a/src/Watcher.cc
+++ b/src/Watcher.cc
@@ -102,7 +102,7 @@ void Watcher::fireCallbacks(uv_async_t *handle) {
     HandleScope scope(it->Env());
     auto err = watcher->mError.size() > 0 ? Error::New(it->Env(), watcher->mError).Value() : it->Env().Null();
     auto events = watcher->mCallbackEvents.toJS(it->Env());
-    it->Call(std::initializer_list<napi_value>{err, events});
+    it->MakeCallback(it->Env().Global(), std::initializer_list<napi_value>{err, events});
 
     // If the iterator was changed, then the callback trigged an unwatch.
     // The iterator will have been set to the next valid callback.


### PR DESCRIPTION
This ensures that the correct async context is set up within Node. Without this, strange behavior occurred where other async work in the event loop would not be run properly.