### PR TITLE
Add engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "prebuild": "prebuild -t 3 -r napi --strip",
     "test": "mocha"
   },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
   "dependencies": {
     "bindings": "^1.5.0",
     "node-addon-api": "^1.6.2",


### PR DESCRIPTION
Adding an engines field to the watcher will make errors clearer that the watcher does not support node 8 and lower.

Related to #19 but without actually compiling to a lower version
