### PR TITLE
Don't use deprecated Azure image anymore

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   - template: azure-pipelines-template.yml
     parameters:
       name: macOS
-      vmImage: macOS-10.13
+      vmImage: macOS-10.15
 
   - template: azure-pipelines-template.yml
     parameters:


### PR DESCRIPTION
https://dev.azure.com/devongovett/devongovett/_build/results?buildId=8049&view=logs&jobId=81a0a40d-e1c6-55f1-066f-a450d17357d3:
> This job was temporarily blocked because it uses a Microsoft hosted agent (MacOS-10.13) that will be permanently removed on March 23rd, 2020.

