### PR TITLE
Add Flow, TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,48 @@
+declare type FilePath = string;
+
+declare namespace ParcelWatcher {
+  export type WatcherBackendType = 
+    | 'fs-events'
+    | 'watchman'
+    | 'inotify'
+    | 'windows'
+    | 'brute-force';
+  export type WatchEventType = 'create' | 'update' | 'delete';
+  export interface WatcherOptions {
+    ignore?: FilePath[];
+    backend?: WatcherBackendType;
+  }
+  export type SubscribeCallback = (
+    err: Error | null,
+    events: WatcherEvent[]
+  ) => unknown;
+  export interface AsyncSubscription {
+    unsubscribe(): Promise<void>;
+  }
+  export interface WatcherEvent {
+    path: FilePath;
+    type: WatchEventType;
+  }
+  export function getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts?: WatcherOptions
+  ): Promise<WatcherEvent[]>;
+  export function subscribe(
+    dir: FilePath,
+    fn: SubscribeCallback,
+    opts?: WatcherOptions
+  ): Promise<AsyncSubscription>;
+  export function unsubscribe(
+    dir: FilePath,
+    fn: SubscribeCallback,
+    opts?: WatcherOptions
+  ): Promise<void>;
+  export function writeSnapshot(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts?: WatcherOptions
+  ): Promise<FilePath>;
+}
+
+export = ParcelWatcher;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,47 +1,47 @@
 declare type FilePath = string;
 
 declare namespace ParcelWatcher {
-  export type WatcherBackendType = 
+  export type BackendType = 
     | 'fs-events'
     | 'watchman'
     | 'inotify'
     | 'windows'
     | 'brute-force';
-  export type WatchEventType = 'create' | 'update' | 'delete';
-  export interface WatcherOptions {
+  export type EventType = 'create' | 'update' | 'delete';
+  export interface Options {
     ignore?: FilePath[];
-    backend?: WatcherBackendType;
+    backend?: BackendType;
   }
   export type SubscribeCallback = (
     err: Error | null,
-    events: WatcherEvent[]
+    events: Event[]
   ) => unknown;
   export interface AsyncSubscription {
     unsubscribe(): Promise<void>;
   }
-  export interface WatcherEvent {
+  export interface Event {
     path: FilePath;
-    type: WatchEventType;
+    type: EventType;
   }
   export function getEventsSince(
     dir: FilePath,
     snapshot: FilePath,
-    opts?: WatcherOptions
-  ): Promise<WatcherEvent[]>;
+    opts?: Options
+  ): Promise<Event[]>;
   export function subscribe(
     dir: FilePath,
     fn: SubscribeCallback,
-    opts?: WatcherOptions
+    opts?: Options
   ): Promise<AsyncSubscription>;
   export function unsubscribe(
     dir: FilePath,
     fn: SubscribeCallback,
-    opts?: WatcherOptions
+    opts?: Options
   ): Promise<void>;
   export function writeSnapshot(
     dir: FilePath,
     snapshot: FilePath,
-    opts?: WatcherOptions
+    opts?: Options
   ): Promise<FilePath>;
 }
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,48 @@
+// @flow
+
+declare type FilePath = string;
+export type WatcherBackendType = 
+  | 'fs-events'
+  | 'watchman'
+  | 'inotify'
+  | 'windows'
+  | 'brute-force';
+export type WatchEventType = 'create' | 'update' | 'delete';
+export type Options = {|
+  ignore?: Array<FilePath>,
+  backend?: WatcherBackendType
+|};
+export type SubscribeCallback = (
+  err: ?Error,
+  events: Array<WatchEvent>
+) => mixed;
+export type AsyncSubscription = {|
+  unsubscribe: () => Promise<void>
+|};
+export type WatchEvent = {|
+  +path: FilePath,
+  +type: WatchEventType
+|};
+
+declare module.exports: {|
+  getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts?: Options
+  ): Promise<Array<WatchEvent>>,
+  subscribe(
+    dir: FilePath,
+    fn: SubscribeCallback,
+    opts?: Options
+  ): Promise<AsyncSubscription>,
+  unsubscribe(
+    dir: FilePath,
+    fn: SubscribeCallback,
+    opts?: Options
+  ): Promise<void>,
+  writeSnapshot(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts?: Options
+  ): Promise<FilePath>,
+|};

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,35 +1,34 @@
 // @flow
-
 declare type FilePath = string;
-export type WatcherBackendType = 
+
+export type BackendType = 
   | 'fs-events'
   | 'watchman'
   | 'inotify'
   | 'windows'
   | 'brute-force';
-export type WatchEventType = 'create' | 'update' | 'delete';
-export type Options = {|
+export type EventType = 'create' | 'update' | 'delete';
+export interface Options {
   ignore?: Array<FilePath>,
-  backend?: WatcherBackendType
-|};
+  backend?: BackendType
+}
 export type SubscribeCallback = (
   err: ?Error,
-  events: Array<WatchEvent>
+  events: Array<Event>
 ) => mixed;
-export type AsyncSubscription = {|
-  unsubscribe: () => Promise<void>
-|};
-export type WatchEvent = {|
-  +path: FilePath,
-  +type: WatchEventType
-|};
-
-declare module.exports: {|
+export interface AsyncSubscription {
+  unsubscribe(): Promise<void>
+}
+export interface Event {
+  path: FilePath,
+  type: EventType
+}
+declare module.exports: {
   getEventsSince(
     dir: FilePath,
     snapshot: FilePath,
     opts?: Options
-  ): Promise<Array<WatchEvent>>,
+  ): Promise<Array<Event>>,
   subscribe(
     dir: FilePath,
     fn: SubscribeCallback,
@@ -44,5 +43,5 @@ declare module.exports: {|
     dir: FilePath,
     snapshot: FilePath,
     opts?: Options
-  ): Promise<FilePath>,
-|};
+  ): Promise<FilePath>
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@parcel/watcher",
   "version": "2.0.0-alpha.8",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/parcel-bundler/watcher.git"


### PR DESCRIPTION
Since Devon suggested that TypeScript types be [directly part of each package](https://github.com/parcel-bundler/parcel/issues/3912#issuecomment-679225893), I've added TypeScript types here. The flow types would replace the `flow-libs/parcel-watcher` of the `parcel-bundler` repository.