### PR TITLE
Fix renames of files that existed before we started watching on macOS

### DIFF
--- a/test/since.js
+++ b/test/since.js
@@ -41,6 +41,13 @@ function testPrecision() {
 const isSecondPrecision = testPrecision();
 
 describe('since', () => {
+  const sleep = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms));
+
+  before(async () => {
+    // wait for tmp dir to be created.
+    await sleep();
+  });
+
   after(async () => {
     try {
       await fs.unlink(snapshotPath);
@@ -48,8 +55,6 @@ describe('since', () => {
   });
 
   backends.forEach(backend => {
-    const sleep = (ms = 10) => new Promise(resolve => setTimeout(resolve, ms));
-
     describe(backend, () => {
       describe('files', () => {
         it('should emit when a file is created', async () => {


### PR DESCRIPTION
T-371 T-609

This fixes renames on macOS so that the delete event for the old name is properly emitted along with the create event for the new name. There was a test for this, but it only covered the case where the original file was created _after_ we started watching. If the file already existed, only the create event for the new name would be emitted.

This removes the checking of our map to see if the file was created previously (obviously wrong 🙈). This does mean, however, that more unnecessary delete events will be emitted in the case of quick events (e.g. create + delete) because macOS coalesces events, but we will just ignore them anyway if they aren't in the graph.