### PR TITLE
Format with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+AllowShortLambdasOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 function normalizeOptions(dir, opts = {}) {
   if (Array.isArray(opts.ignore)) {
     opts = Object.assign({}, opts, {
-      ignore: opts.ignore.map(ignore => path.resolve(dir, ignore)),
+      ignore: opts.ignore.map((ignore) => path.resolve(dir, ignore)),
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "prebuild": "prebuildify --napi --strip --tag-libc -t 10.0.0",
-    "format": "prettier --write \"./**/*.{js,json,md}\"",
+    "format": "prettier --write \"./**/*.{js,json,md}\" && clang-format -i -style=file src/**/*.{cc,hh}",
     "install": "node-gyp-build",
     "rebuild": "node-gyp rebuild -j 8 --debug --verbose",
     "test": "mocha"

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -1,11 +1,13 @@
 #ifndef INOTIFY_H
 #define INOTIFY_H
 
-#include <unordered_map>
 #include <sys/inotify.h>
-#include "../shared/BruteForceBackend.hh"
+
+#include <unordered_map>
+
 #include "../DirTree.hh"
 #include "../Signal.hh"
+#include "../shared/BruteForceBackend.hh"
 
 struct InotifySubscription {
   std::shared_ptr<DirTree> tree;
@@ -14,21 +16,26 @@ struct InotifySubscription {
 };
 
 class InotifyBackend : public BruteForceBackend {
-public:
+ public:
   void start() override;
   ~InotifyBackend();
   void subscribe(Watcher &watcher) override;
   void unsubscribe(Watcher &watcher) override;
-private:
+
+ private:
   int mPipe[2];
   int mInotify;
-  std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
+  std::unordered_multimap<int, std::shared_ptr<InotifySubscription>>
+      mSubscriptions;
   Signal mEndedSignal;
 
-  void watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree);
+  void watchDir(Watcher &watcher, DirEntry *entry,
+                std::shared_ptr<DirTree> tree);
   void handleEvents();
-  void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
-  bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);
+  void handleEvent(struct inotify_event *event,
+                   std::unordered_set<Watcher *> &watchers);
+  bool handleSubscription(struct inotify_event *event,
+                          std::shared_ptr<InotifySubscription> sub);
 };
 
 #endif

--- a/src/macos/FSEventsBackend.hh
+++ b/src/macos/FSEventsBackend.hh
@@ -2,17 +2,19 @@
 #define FS_EVENTS_H
 
 #include <CoreServices/CoreServices.h>
+
 #include "../Backend.hh"
 
 class FSEventsBackend : public Backend {
-public:
+ public:
   void start() override;
   ~FSEventsBackend();
   void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
   void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
   void subscribe(Watcher &watcher) override;
   void unsubscribe(Watcher &watcher) override;
-private:
+
+ private:
   void startStream(Watcher &watcher, FSEventStreamEventId id);
   CFRunLoopRef mRunLoop;
 };

--- a/src/shared/BruteForceBackend.cc
+++ b/src/shared/BruteForceBackend.cc
@@ -1,10 +1,13 @@
-#include <string>
-#include <fstream>
-#include "../DirTree.hh"
-#include "../Event.hh"
 #include "./BruteForceBackend.hh"
 
-std::shared_ptr<DirTree> BruteForceBackend::getTree(Watcher &watcher, bool shouldRead) {
+#include <fstream>
+#include <string>
+
+#include "../DirTree.hh"
+#include "../Event.hh"
+
+std::shared_ptr<DirTree> BruteForceBackend::getTree(Watcher &watcher,
+                                                    bool shouldRead) {
   auto tree = DirTree::getCached(watcher.mDir);
 
   // If the tree is not complete, read it if needed.
@@ -16,14 +19,16 @@ std::shared_ptr<DirTree> BruteForceBackend::getTree(Watcher &watcher, bool shoul
   return tree;
 }
 
-void BruteForceBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath) {
+void BruteForceBackend::writeSnapshot(Watcher &watcher,
+                                      std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   auto tree = getTree(watcher);
   std::ofstream ofs(*snapshotPath);
   tree->write(ofs);
 }
 
-void BruteForceBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath) {
+void BruteForceBackend::getEventsSince(Watcher &watcher,
+                                       std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   std::ifstream ifs(*snapshotPath);
   if (ifs.fail()) {

--- a/src/shared/BruteForceBackend.hh
+++ b/src/shared/BruteForceBackend.hh
@@ -6,7 +6,7 @@
 #include "../Watcher.hh"
 
 class BruteForceBackend : public Backend {
-public:
+ public:
   void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
   void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
   void subscribe(Watcher &watcher) override {
@@ -18,7 +18,8 @@ public:
   }
 
   std::shared_ptr<DirTree> getTree(Watcher &watcher, bool shouldRead = true);
-private:
+
+ private:
   void readTree(Watcher &watcher, std::shared_ptr<DirTree> tree);
 };
 

--- a/src/unix/fts.cc
+++ b/src/unix/fts.cc
@@ -7,6 +7,7 @@
 #define __THROW
 
 #include <fts.h>
+
 #include "../DirTree.hh"
 #include "../shared/BruteForceBackend.hh"
 
@@ -15,8 +16,9 @@
 #define st_mtim st_mtimespec
 #endif
 
-void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
-  char *paths[2] {(char *)watcher.mDir.c_str(), NULL};
+void BruteForceBackend::readTree(Watcher &watcher,
+                                 std::shared_ptr<DirTree> tree) {
+  char *paths[2]{(char *)watcher.mDir.c_str(), NULL};
   FTS *fts = fts_open(paths, FTS_NOCHDIR | FTS_PHYSICAL, NULL);
   if (!fts) {
     throw WatcherError(strerror(errno), &watcher);
@@ -41,7 +43,8 @@ void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree
       continue;
     }
 
-    tree->add(node->fts_path, CONVERT_TIME(node->fts_statp->st_mtim), (node->fts_info & FTS_D) == FTS_D);
+    tree->add(node->fts_path, CONVERT_TIME(node->fts_statp->st_mtim),
+              (node->fts_info & FTS_D) == FTS_D);
     isRoot = false;
   }
 

--- a/src/unix/legacy.cc
+++ b/src/unix/legacy.cc
@@ -7,9 +7,9 @@
 #define __THROW
 
 #ifdef _LIBC
-# include <include/sys/stat.h>
+#include <include/sys/stat.h>
 #else
-# include <sys/stat.h>
+#include <sys/stat.h>
 #endif
 #include <dirent.h>
 #include <unistd.h>
@@ -23,45 +23,49 @@
 #endif
 #define ISDOT(a) (a[0] == '.' && (!a[1] || (a[1] == '.' && !a[2])))
 
-void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const char *relative, int parent_fd, const std::string dirname) {
-    int open_flags = (O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
-    int new_fd = openat(parent_fd, relative, open_flags);
+void iterateDir(Watcher &watcher, const std::shared_ptr<DirTree> tree,
+                const char *relative, int parent_fd,
+                const std::string dirname) {
+  int open_flags =
+      (O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
+  int new_fd = openat(parent_fd, relative, open_flags);
 
-    struct stat rootAttributes;
-    fstatat(new_fd, ".", &rootAttributes, AT_SYMLINK_NOFOLLOW);
-    tree->add(dirname, CONVERT_TIME(rootAttributes.st_mtim), true);
+  struct stat rootAttributes;
+  fstatat(new_fd, ".", &rootAttributes, AT_SYMLINK_NOFOLLOW);
+  tree->add(dirname, CONVERT_TIME(rootAttributes.st_mtim), true);
 
-    if (DIR *dir = fdopendir(new_fd)) {
-        while (struct dirent *ent = (errno = 0, readdir(dir))) {
-            if (ISDOT(ent->d_name)) continue;
+  if (DIR *dir = fdopendir(new_fd)) {
+    while (struct dirent *ent = (errno = 0, readdir(dir))) {
+      if (ISDOT(ent->d_name)) continue;
 
-            std::string fullPath = dirname + "/" + ent->d_name;
+      std::string fullPath = dirname + "/" + ent->d_name;
 
-            if (watcher.mIgnore.count(fullPath) == 0) {
-                struct stat attrib;
-                fstatat(new_fd, ent->d_name, &attrib, AT_SYMLINK_NOFOLLOW);
-                bool isDir = ent->d_type == DT_DIR;
+      if (watcher.mIgnore.count(fullPath) == 0) {
+        struct stat attrib;
+        fstatat(new_fd, ent->d_name, &attrib, AT_SYMLINK_NOFOLLOW);
+        bool isDir = ent->d_type == DT_DIR;
 
-                if (isDir) {
-                    iterateDir(watcher, tree, ent->d_name, new_fd, fullPath);
-                } else {
-                    tree->add(fullPath, CONVERT_TIME(attrib.st_mtim), isDir);
-                }
-            }
+        if (isDir) {
+          iterateDir(watcher, tree, ent->d_name, new_fd, fullPath);
+        } else {
+          tree->add(fullPath, CONVERT_TIME(attrib.st_mtim), isDir);
         }
+      }
     }
+  }
 
-    close(new_fd);
+  close(new_fd);
 
-    if (errno) {
-        throw WatcherError(strerror(errno), &watcher);
-    }
+  if (errno) {
+    throw WatcherError(strerror(errno), &watcher);
+  }
 }
 
-void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr <DirTree> tree) {
-    int fd = open(watcher.mDir.c_str(), O_RDONLY);
-    if (fd) {
-        iterateDir(watcher, tree, ".", fd, watcher.mDir);
-        close(fd);
-    }
+void BruteForceBackend::readTree(Watcher &watcher,
+                                 std::shared_ptr<DirTree> tree) {
+  int fd = open(watcher.mDir.c_str(), O_RDONLY);
+  if (fd) {
+    iterateDir(watcher, tree, ".", fd, watcher.mDir);
+    close(fd);
+  }
 }

--- a/src/watchman/BSER.cc
+++ b/src/watchman/BSER.cc
@@ -1,10 +1,11 @@
-#include <stdint.h>
 #include "./BSER.hh"
+
+#include <stdint.h>
 
 BSERType decodeType(std::istream &iss) {
   int8_t type;
-  iss.read(reinterpret_cast<char*>(&type), sizeof(type));
-  return (BSERType) type;
+  iss.read(reinterpret_cast<char *>(&type), sizeof(type));
+  return (BSERType)type;
 }
 
 void expectType(std::istream &iss, BSERType expected) {
@@ -16,12 +17,12 @@ void expectType(std::istream &iss, BSERType expected) {
 
 void encodeType(std::ostream &oss, BSERType type) {
   int8_t t = (int8_t)type;
-  oss.write(reinterpret_cast<char*>(&t), sizeof(t));
+  oss.write(reinterpret_cast<char *>(&t), sizeof(t));
 }
 
-template<typename T>
+template <typename T>
 class Value : public BSERValue {
-public:
+ public:
   T value;
   Value(T val) {
     value = val;
@@ -31,7 +32,7 @@ public:
 };
 
 class BSERInteger : public Value<int64_t> {
-public:
+ public:
   BSERInteger(int64_t value) : Value(value) {}
   BSERInteger(std::istream &iss) {
     int8_t int8;
@@ -43,19 +44,19 @@ public:
 
     switch (type) {
       case BSER_INT8:
-        iss.read(reinterpret_cast<char*>(&int8), sizeof(int8));
+        iss.read(reinterpret_cast<char *>(&int8), sizeof(int8));
         value = int8;
         break;
       case BSER_INT16:
-        iss.read(reinterpret_cast<char*>(&int16), sizeof(int16));
+        iss.read(reinterpret_cast<char *>(&int16), sizeof(int16));
         value = int16;
         break;
       case BSER_INT32:
-        iss.read(reinterpret_cast<char*>(&int32), sizeof(int32));
+        iss.read(reinterpret_cast<char *>(&int32), sizeof(int32));
         value = int32;
         break;
       case BSER_INT64:
-        iss.read(reinterpret_cast<char*>(&int64), sizeof(int64));
+        iss.read(reinterpret_cast<char *>(&int64), sizeof(int64));
         value = int64;
         break;
       default:
@@ -71,24 +72,24 @@ public:
     if (value <= INT8_MAX) {
       encodeType(oss, BSER_INT8);
       int8_t v = (int8_t)value;
-      oss.write(reinterpret_cast<char*>(&v), sizeof(v));
+      oss.write(reinterpret_cast<char *>(&v), sizeof(v));
     } else if (value <= INT16_MAX) {
       encodeType(oss, BSER_INT16);
       int16_t v = (int16_t)value;
-      oss.write(reinterpret_cast<char*>(&v), sizeof(v));
+      oss.write(reinterpret_cast<char *>(&v), sizeof(v));
     } else if (value <= INT32_MAX) {
       encodeType(oss, BSER_INT32);
       int32_t v = (int32_t)value;
-      oss.write(reinterpret_cast<char*>(&v), sizeof(v));
+      oss.write(reinterpret_cast<char *>(&v), sizeof(v));
     } else {
       encodeType(oss, BSER_INT64);
-      oss.write(reinterpret_cast<char*>(&value), sizeof(value));
+      oss.write(reinterpret_cast<char *>(&value), sizeof(value));
     }
   }
 };
 
 class BSERArray : public Value<BSER::Array> {
-public:
+ public:
   BSERArray() : Value() {}
   BSERArray(BSER::Array value) : Value(value) {}
   BSERArray(std::istream &iss) {
@@ -98,7 +99,7 @@ public:
       value.push_back(BSER(iss));
     }
   }
-  
+
   BSER::Array arrayValue() override {
     return value;
   }
@@ -113,7 +114,7 @@ public:
 };
 
 class BSERString : public Value<std::string> {
-public:
+ public:
   BSERString(std::string value) : Value(value) {}
   BSERString(std::istream &iss) {
     expectType(iss, BSER_STRING);
@@ -134,7 +135,7 @@ public:
 };
 
 class BSERObject : public Value<BSER::Object> {
-public:
+ public:
   BSERObject() : Value() {}
   BSERObject(BSER::Object value) : Value(value) {}
   BSERObject(std::istream &iss) {
@@ -162,11 +163,11 @@ public:
 };
 
 class BSERDouble : public Value<double> {
-public:
+ public:
   BSERDouble(double value) : Value(value) {}
   BSERDouble(std::istream &iss) {
     expectType(iss, BSER_REAL);
-    iss.read(reinterpret_cast<char*>(&value), sizeof(value));
+    iss.read(reinterpret_cast<char *>(&value), sizeof(value));
   }
 
   double doubleValue() override {
@@ -175,22 +176,24 @@ public:
 
   void encode(std::ostream &oss) override {
     encodeType(oss, BSER_REAL);
-    oss.write(reinterpret_cast<char*>(&value), sizeof(value));
+    oss.write(reinterpret_cast<char *>(&value), sizeof(value));
   }
 };
 
 class BSERBoolean : public Value<bool> {
-public:
+ public:
   BSERBoolean(bool value) : Value(value) {}
-  bool boolValue() override { return value; }
+  bool boolValue() override {
+    return value;
+  }
   void encode(std::ostream &oss) override {
     int8_t t = value == true ? BSER_BOOL_TRUE : BSER_BOOL_FALSE;
-    oss.write(reinterpret_cast<char*>(&t), sizeof(t));
+    oss.write(reinterpret_cast<char *>(&t), sizeof(t));
   }
 };
 
 class BSERNull : public Value<bool> {
-public:
+ public:
   BSERNull() : Value(false) {}
   void encode(std::ostream &oss) override {
     encodeType(oss, BSER_NULL);
@@ -270,12 +273,24 @@ BSER::BSER(int64_t value) : m_ptr(std::make_shared<BSERInteger>(value)) {}
 BSER::BSER(double value) : m_ptr(std::make_shared<BSERDouble>(value)) {}
 BSER::BSER(bool value) : m_ptr(std::make_shared<BSERBoolean>(value)) {}
 
-BSER::Array BSER::arrayValue() { return m_ptr->arrayValue(); }
-BSER::Object BSER::objectValue() { return m_ptr->objectValue(); }
-std::string BSER::stringValue() { return m_ptr->stringValue(); }
-int64_t BSER::intValue() { return m_ptr->intValue(); }
-double BSER::doubleValue() { return m_ptr->doubleValue(); }
-bool BSER::boolValue() { return m_ptr->boolValue(); }
+BSER::Array BSER::arrayValue() {
+  return m_ptr->arrayValue();
+}
+BSER::Object BSER::objectValue() {
+  return m_ptr->objectValue();
+}
+std::string BSER::stringValue() {
+  return m_ptr->stringValue();
+}
+int64_t BSER::intValue() {
+  return m_ptr->intValue();
+}
+double BSER::doubleValue() {
+  return m_ptr->doubleValue();
+}
+bool BSER::boolValue() {
+  return m_ptr->boolValue();
+}
 void BSER::encode(std::ostream &oss) {
   m_ptr->encode(oss);
 }
@@ -295,7 +310,7 @@ std::string BSER::encode() {
 
   std::ostringstream res(std::ios_base::binary);
   res.write("\x00\x01", 2);
-  
+
   BSERInteger(oss.str().size()).encode(res);
   res << oss.str();
   return res.str();

--- a/src/watchman/BSER.hh
+++ b/src/watchman/BSER.hh
@@ -1,11 +1,11 @@
 #ifndef BSER_H
 #define BSER_H
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <unordered_map>
 #include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 enum BSERType {
   BSER_ARRAY = 0x00,
@@ -25,7 +25,7 @@ enum BSERType {
 class BSERValue;
 
 class BSER {
-public:
+ public:
   typedef std::vector<BSER> Array;
   typedef std::unordered_map<std::string, BSER> Object;
 
@@ -49,19 +49,32 @@ public:
 
   static int64_t decodeLength(std::istream &iss);
   std::string encode();
-private:
+
+ private:
   std::shared_ptr<BSERValue> m_ptr;
 };
 
 class BSERValue {
-protected:
+ protected:
   friend class BSER;
-  virtual BSER::Array arrayValue() { return BSER::Array(); }
-  virtual BSER::Object objectValue() { return BSER::Object(); }
-  virtual std::string stringValue() { return std::string(); }
-  virtual int64_t intValue() { return 0; }
-  virtual double doubleValue() { return 0; }
-  virtual bool boolValue() { return false; }
+  virtual BSER::Array arrayValue() {
+    return BSER::Array();
+  }
+  virtual BSER::Object objectValue() {
+    return BSER::Object();
+  }
+  virtual std::string stringValue() {
+    return std::string();
+  }
+  virtual int64_t intValue() {
+    return 0;
+  }
+  virtual double doubleValue() {
+    return 0;
+  }
+  virtual bool boolValue() {
+    return false;
+  }
   virtual void encode(std::ostream &oss) {}
   virtual ~BSERValue() {}
 };

--- a/src/watchman/IPC.hh
+++ b/src/watchman/IPC.hh
@@ -1,174 +1,172 @@
 #ifndef IPC_H
 #define IPC_H
 
-#include <string>
 #include <stdlib.h>
+
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <unistd.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 #endif
 
 class IPC {
-public:
+ public:
   IPC(std::string path) {
     mStopped = false;
-    #ifdef _WIN32
-      while (true) {
-        mPipe = CreateFile(
-          path.data(), // pipe name 
-          GENERIC_READ | GENERIC_WRITE, // read and write access 
-          0, // no sharing 
-          NULL, // default security attributes
-          OPEN_EXISTING, // opens existing pipe 
-          FILE_FLAG_OVERLAPPED, // attributes 
-          NULL // no template file
-        );
+#ifdef _WIN32
+    while (true) {
+      mPipe = CreateFile(path.data(),                   // pipe name
+                         GENERIC_READ | GENERIC_WRITE,  // read and write access
+                         0,                             // no sharing
+                         NULL,                  // default security attributes
+                         OPEN_EXISTING,         // opens existing pipe
+                         FILE_FLAG_OVERLAPPED,  // attributes
+                         NULL                   // no template file
+      );
 
-        if (mPipe != INVALID_HANDLE_VALUE) {
-          break;
-        }
-
-        if (GetLastError() != ERROR_PIPE_BUSY) {
-          throw std::runtime_error("Could not open pipe");
-        }
-
-        // Wait for pipe to become available if it is busy
-        if (!WaitNamedPipe(path.data(), 30000)) {
-          throw std::runtime_error("Error waiting for pipe");
-        }
+      if (mPipe != INVALID_HANDLE_VALUE) {
+        break;
       }
 
-      mReader = CreateEvent(NULL, true, false, NULL);
-      mWriter = CreateEvent(NULL, true, false, NULL);
-    #else
-      struct sockaddr_un addr;
-      memset(&addr, 0, sizeof(addr));
-      addr.sun_family = AF_UNIX;
-      strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
-
-      mSock = socket(AF_UNIX, SOCK_STREAM, 0);
-      if (connect(mSock, (struct sockaddr *) &addr, sizeof(struct sockaddr_un))) {
-        throw std::runtime_error("Error connecting to socket");
+      if (GetLastError() != ERROR_PIPE_BUSY) {
+        throw std::runtime_error("Could not open pipe");
       }
-    #endif
+
+      // Wait for pipe to become available if it is busy
+      if (!WaitNamedPipe(path.data(), 30000)) {
+        throw std::runtime_error("Error waiting for pipe");
+      }
+    }
+
+    mReader = CreateEvent(NULL, true, false, NULL);
+    mWriter = CreateEvent(NULL, true, false, NULL);
+#else
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+
+    mSock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (connect(mSock, (struct sockaddr *)&addr, sizeof(struct sockaddr_un))) {
+      throw std::runtime_error("Error connecting to socket");
+    }
+#endif
   }
 
   ~IPC() {
     mStopped = true;
-    #ifdef _WIN32
-      CancelIo(mPipe);
-      CloseHandle(mPipe);
-      CloseHandle(mReader);
-      CloseHandle(mWriter);
-    #else
-      shutdown(mSock, SHUT_RDWR);
-    #endif
+#ifdef _WIN32
+    CancelIo(mPipe);
+    CloseHandle(mPipe);
+    CloseHandle(mReader);
+    CloseHandle(mWriter);
+#else
+    shutdown(mSock, SHUT_RDWR);
+#endif
   }
 
   void write(std::string buf) {
-    #ifdef _WIN32
-      OVERLAPPED overlapped;
-      overlapped.hEvent = mWriter;
-      bool success = WriteFile(
-        mPipe, // pipe handle 
-        buf.data(), // message 
-        buf.size(), // message length 
-        NULL, // bytes written 
-        &overlapped // overlapped 
-      );
+#ifdef _WIN32
+    OVERLAPPED overlapped;
+    overlapped.hEvent = mWriter;
+    bool success = WriteFile(mPipe,       // pipe handle
+                             buf.data(),  // message
+                             buf.size(),  // message length
+                             NULL,        // bytes written
+                             &overlapped  // overlapped
+    );
 
-      if (mStopped) {
-        return;
+    if (mStopped) {
+      return;
+    }
+
+    if (!success) {
+      if (GetLastError() != ERROR_IO_PENDING) {
+        throw std::runtime_error("Write error");
       }
+    }
 
-      if (!success) {
-        if (GetLastError() != ERROR_IO_PENDING) {
+    DWORD written;
+    success = GetOverlappedResult(mPipe, &overlapped, &written, true);
+    if (!success) {
+      throw std::runtime_error("GetOverlappedResult failed");
+    }
+
+    if (written != buf.size()) {
+      throw std::runtime_error("Wrong number of bytes written");
+    }
+#else
+    int r = 0;
+    for (unsigned int i = 0; i != buf.size(); i += r) {
+      r = ::write(mSock, &buf[i], buf.size() - i);
+      if (r == -1) {
+        if (errno == EAGAIN) {
+          r = 0;
+        } else if (mStopped) {
+          return;
+        } else {
           throw std::runtime_error("Write error");
         }
       }
-
-      DWORD written;
-      success = GetOverlappedResult(mPipe, &overlapped, &written, true);
-      if (!success) {
-        throw std::runtime_error("GetOverlappedResult failed");
-      }
-
-      if (written != buf.size()) {
-        throw std::runtime_error("Wrong number of bytes written");
-      }
-    #else
-      int r = 0;
-      for (unsigned int i = 0; i != buf.size(); i += r) {
-        r = ::write(mSock, &buf[i], buf.size() - i);
-        if (r == -1) {
-          if (errno == EAGAIN) {
-            r = 0;
-          } else if (mStopped) {
-            return;
-          } else {
-            throw std::runtime_error("Write error");
-          }
-        }
-      }
-    #endif
+    }
+#endif
   }
 
   int read(char *buf, size_t len) {
-    #ifdef _WIN32
-      OVERLAPPED overlapped;
-      overlapped.hEvent = mReader;
-      bool success = ReadFile(
-        mPipe, // pipe handle 
-        buf, // buffer to receive reply 
-        len, // size of buffer 
-        NULL, // number of bytes read 
-        &overlapped // overlapped 
-      );
+#ifdef _WIN32
+    OVERLAPPED overlapped;
+    overlapped.hEvent = mReader;
+    bool success = ReadFile(mPipe,       // pipe handle
+                            buf,         // buffer to receive reply
+                            len,         // size of buffer
+                            NULL,        // number of bytes read
+                            &overlapped  // overlapped
+    );
 
-      if (!success && !mStopped) {
-        if (GetLastError() != ERROR_IO_PENDING) {
-          throw std::runtime_error("Read error");
-        }
+    if (!success && !mStopped) {
+      if (GetLastError() != ERROR_IO_PENDING) {
+        throw std::runtime_error("Read error");
+      }
+    }
+
+    DWORD read = 0;
+    success = GetOverlappedResult(mPipe, &overlapped, &read, true);
+    if (!success && !mStopped) {
+      throw std::runtime_error("GetOverlappedResult failed");
+    }
+
+    return read;
+#else
+    int r = ::read(mSock, buf, len);
+    if (r == 0 && !mStopped) {
+      throw std::runtime_error("Socket ended unexpectedly");
+    }
+
+    if (r < 0) {
+      if (mStopped) {
+        return 0;
       }
 
-      DWORD read = 0;
-      success = GetOverlappedResult(mPipe, &overlapped, &read, true);
-      if (!success && !mStopped) {
-        throw std::runtime_error("GetOverlappedResult failed");
-      }
-      
-      return read;
-    #else
-      int r = ::read(mSock, buf, len);
-      if (r == 0 && !mStopped) {
-        throw std::runtime_error("Socket ended unexpectedly");
-      }
+      throw std::runtime_error(strerror(errno));
+    }
 
-      if (r < 0) {
-        if (mStopped) {
-          return 0;
-        }
-
-        throw std::runtime_error(strerror(errno));
-      }
-
-      return r;
-    #endif
+    return r;
+#endif
   }
 
-private:
+ private:
   bool mStopped;
-  #ifdef _WIN32
-    HANDLE mPipe;
-    HANDLE mReader;
-    HANDLE mWriter;
-  #else
-    int mSock;
-  #endif
+#ifdef _WIN32
+  HANDLE mPipe;
+  HANDLE mReader;
+  HANDLE mWriter;
+#else
+  int mSock;
+#endif
 };
 
 #endif

--- a/src/watchman/WatchmanBackend.hh
+++ b/src/watchman/WatchmanBackend.hh
@@ -2,21 +2,22 @@
 #define WATCHMAN_H
 
 #include "../Backend.hh"
-#include "./BSER.hh"
 #include "../Signal.hh"
+#include "./BSER.hh"
 #include "./IPC.hh"
 
 class WatchmanBackend : public Backend {
-public:
+ public:
   static bool checkAvailable();
   void start() override;
-  WatchmanBackend() : mStopped(false) {};
+  WatchmanBackend() : mStopped(false){};
   ~WatchmanBackend();
   void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
   void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
   void subscribe(Watcher &watcher) override;
   void unsubscribe(Watcher &watcher) override;
-private:
+
+ private:
   std::unique_ptr<IPC> mIPC;
   Signal mRequestSignal;
   Signal mResponseSignal;

--- a/src/windows/WindowsBackend.hh
+++ b/src/windows/WindowsBackend.hh
@@ -1,17 +1,19 @@
 #ifndef WINDOWS_H
 #define WINDOWS_H
 
-#include <winsock2.h>
 #include <windows.h>
+#include <winsock2.h>
+
 #include "../shared/BruteForceBackend.hh"
 
 class WindowsBackend : public BruteForceBackend {
-public:
+ public:
   void start() override;
   ~WindowsBackend();
   void subscribe(Watcher &watcher) override;
   void unsubscribe(Watcher &watcher) override;
-private:
+
+ private:
   bool mRunning;
 };
 

--- a/src/windows/win_utils.cc
+++ b/src/windows/win_utils.cc
@@ -1,7 +1,8 @@
 #include "./win_utils.hh"
 
 std::wstring utf8ToUtf16(std::string input) {
-  unsigned int len = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, NULL, 0);
+  unsigned int len =
+      MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, NULL, 0);
   WCHAR *output = new WCHAR[len];
   MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, output, len);
   std::wstring res(output);
@@ -10,7 +11,8 @@ std::wstring utf8ToUtf16(std::string input) {
 }
 
 std::string utf16ToUtf8(const WCHAR *input, size_t length) {
-  unsigned int len = WideCharToMultiByte(CP_UTF8, 0, input, length, NULL, 0, NULL, NULL);
+  unsigned int len =
+      WideCharToMultiByte(CP_UTF8, 0, input, length, NULL, 0, NULL, NULL);
   char *output = new char[len + 1];
   WideCharToMultiByte(CP_UTF8, 0, input, length, output, len, NULL, NULL);
   output[len] = '\0';

--- a/src/windows/win_utils.hh
+++ b/src/windows/win_utils.hh
@@ -1,8 +1,9 @@
 #ifndef WIN_UTILS_H
 #define WIN_UTILS_H
 
-#include <string>
 #include <windows.h>
+
+#include <string>
 
 std::wstring utf8ToUtf16(std::string input);
 std::string utf16ToUtf8(const WCHAR *input, size_t length);

--- a/test/since.js
+++ b/test/since.js
@@ -6,9 +6,7 @@ const path = require('path');
 const snapshotPath = path.join(__dirname, 'snapshot.txt');
 const tmpDir = path.join(
   fs.realpathSync(require('os').tmpdir()),
-  Math.random()
-    .toString(31)
-    .slice(2),
+  Math.random().toString(31).slice(2),
 );
 fs.mkdirpSync(tmpDir);
 
@@ -23,13 +21,7 @@ if (process.platform === 'darwin') {
 
 let c = 0;
 const getFilename = (...dir) =>
-  path.join(
-    tmpDir,
-    ...dir,
-    `test${c++}${Math.random()
-      .toString(31)
-      .slice(2)}`,
-  );
+  path.join(tmpDir, ...dir, `test${c++}${Math.random().toString(31).slice(2)}`);
 
 function testPrecision() {
   let f = getFilename();
@@ -41,7 +33,7 @@ function testPrecision() {
 const isSecondPrecision = testPrecision();
 
 describe('since', () => {
-  const sleep = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms));
+  const sleep = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms));
 
   before(async () => {
     // wait for tmp dir to be created.
@@ -54,7 +46,7 @@ describe('since', () => {
     } catch (err) {}
   });
 
-  backends.forEach(backend => {
+  backends.forEach((backend) => {
     describe(backend, () => {
       describe('files', () => {
         it('should emit when a file is created', async () => {
@@ -518,9 +510,7 @@ describe('since', () => {
         it('should error if the watched directory does not exist', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
 
           let threw = false;
@@ -541,9 +531,7 @@ describe('since', () => {
 
           let file = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.writeFileSync(file, 'test');
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -14,13 +14,13 @@ if (process.platform === 'darwin') {
 }
 
 describe('watcher', () => {
-  backends.forEach(backend => {
+  backends.forEach((backend) => {
     describe(backend, () => {
       let tmpDir;
       let cbs = [];
       let subscribed = false;
       let nextEvent = () => {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           cbs.push(resolve);
         });
       };
@@ -44,18 +44,14 @@ describe('watcher', () => {
         path.join(
           tmpDir,
           ...dir,
-          `test${c++}${Math.random()
-            .toString(31)
-            .slice(2)}`,
+          `test${c++}${Math.random().toString(31).slice(2)}`,
         );
       let ignoreDir, ignoreFile, fileToRename, dirToRename, sub;
 
       before(async () => {
         tmpDir = path.join(
           fs.realpathSync(require('os').tmpdir()),
-          Math.random()
-            .toString(31)
-            .slice(2),
+          Math.random().toString(31).slice(2),
         );
         fs.mkdirpSync(tmpDir);
         ignoreDir = getFilename();
@@ -64,7 +60,7 @@ describe('watcher', () => {
         dirToRename = getFilename();
         fs.writeFileSync(fileToRename, 'hi');
         fs.mkdirpSync(dirToRename);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 100));
         sub = await watcher.subscribe(tmpDir, fn, {
           backend,
           ignore: [ignoreDir, ignoreFile],
@@ -445,15 +441,13 @@ describe('watcher', () => {
         it('should support multiple watchers for the same directory', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.mkdirpSync(dir);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           function listen() {
-            return new Promise(async resolve => {
+            return new Promise(async (resolve) => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
@@ -467,7 +461,7 @@ describe('watcher', () => {
 
           let l1 = listen();
           let l2 = listen();
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir, 'test1.txt'), 'test1');
 
@@ -481,15 +475,13 @@ describe('watcher', () => {
         it('should support multiple watchers for the same directory with different ignore paths', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.mkdirpSync(dir);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           function listen(ignore) {
-            return new Promise(async resolve => {
+            return new Promise(async (resolve) => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
@@ -503,7 +495,7 @@ describe('watcher', () => {
 
           let l1 = listen([path.join(dir, 'test1.txt')]);
           let l2 = listen([path.join(dir, 'test2.txt')]);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir, 'test1.txt'), 'test1');
           fs.writeFile(path.join(dir, 'test2.txt'), 'test1');
@@ -518,22 +510,18 @@ describe('watcher', () => {
         it('should support multiple watchers for different directories', async () => {
           let dir1 = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           let dir2 = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.mkdirpSync(dir1);
           fs.mkdirpSync(dir2);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           function listen(dir) {
-            return new Promise(async resolve => {
+            return new Promise(async (resolve) => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
@@ -547,7 +535,7 @@ describe('watcher', () => {
 
           let l1 = listen(dir1);
           let l2 = listen(dir2);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir1, 'test1.txt'), 'test1');
           fs.writeFile(path.join(dir2, 'test1.txt'), 'test1');
@@ -562,21 +550,17 @@ describe('watcher', () => {
         it('should work when getting events since a snapshot on an already watched directory', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           let snapshot = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.mkdirpSync(dir);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           function listen(dir) {
-            return new Promise(async resolve => {
+            return new Promise(async (resolve) => {
               let sub = await watcher.subscribe(
                 dir,
                 (err, events) => {
@@ -588,16 +572,16 @@ describe('watcher', () => {
           }
 
           let l = listen(dir);
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           await fs.writeFile(path.join(dir, 'test1.txt'), 'hello1');
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           await watcher.writeSnapshot(dir, snapshot, {backend});
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
 
           await fs.writeFile(path.join(dir, 'test2.txt'), 'hello2');
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise((resolve) => setTimeout(resolve, 100));
 
           let [watched, sub] = await l;
           assert.deepEqual(watched, [
@@ -617,9 +601,7 @@ describe('watcher', () => {
         it('should error if the watched directory does not exist', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
 
           let threw = false;
@@ -646,9 +628,7 @@ describe('watcher', () => {
 
           let file = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.writeFileSync(file, 'test');
 
@@ -676,14 +656,12 @@ describe('watcher', () => {
       it('should emit an error when watchman dies', async () => {
         let dir = path.join(
           fs.realpathSync(require('os').tmpdir()),
-          Math.random()
-            .toString(31)
-            .slice(2),
+          Math.random().toString(31).slice(2),
         );
         fs.mkdirpSync(dir);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-        let p = new Promise(resolve => {
+        let p = new Promise((resolve) => {
           watcher.subscribe(
             dir,
             (err, events) => {


### PR DESCRIPTION
This automatically formats the C++ code with an approximation of the existing style, roughly Google style (2 spaces, braces on same line) plus preventing short functions and lambdas from being collapsed.

The majority of the remaining diff churn in this change is from changing the line length to 80, which is consistent with the rest of Parcel projects. Let me know if you'd rather keep this diff minimal by extending this.

This also has clang-format in the yarn format script, though conforming to style is not checked in pipelines.