### PR TITLE
fix memory leak on linux

### DIFF
--- a/src/unix/legacy.cc
+++ b/src/unix/legacy.cc
@@ -23,7 +23,7 @@
 #endif
 #define ISDOT(a) (a[0] == '.' && (!a[1] || (a[1] == '.' && !a[2])))
 
-void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const char *relative, int parent_fd, const std::string dirname) {
+void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const char *relative, int parent_fd, const std::string &dirname) {
     int open_flags = (O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
     int new_fd = openat(parent_fd, relative, open_flags);
 
@@ -49,9 +49,11 @@ void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const ch
                 }
             }
         }
-    }
 
-    close(new_fd);
+        closedir(dir);
+    } else {
+        close(new_fd);
+    }
 
     if (errno) {
         throw WatcherError(strerror(errno), &watcher);


### PR DESCRIPTION
There was a memory leak in the legacy `readTree` utility where the file descriptor was being closed but not the directory stream, so closed it to close the directory stream instead...

Fixes #55 