### PR TITLE
linux: indicate path that failed to watch via inotify

### DIFF
--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -75,7 +75,7 @@ void InotifyBackend::subscribe(Watcher &watcher) {
 void InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree) {
   int wd = inotify_add_watch(mInotify, entry->path.c_str(), INOTIFY_MASK);
   if (wd == -1) {
-    throw WatcherError(std::string("inotify_add_watch failed: ") + strerror(errno), &watcher);
+    throw WatcherError(std::string("inotify_add_watch on '") + entry->path + std::string("' failed: ") + strerror(errno), &watcher);
   }
 
   std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>();


### PR DESCRIPTION
I find it somewhat useful to know the path that failed to watch via `inotify` because if the path is a symbolic link, VS Code users will have to explicitly add that path for watching via settings.