### PR TITLE
Linux: should handle `inotify_add_watch` errors more gracefully

### DIFF
--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -159,7 +159,9 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
     watcher->mEvents.create(path);
 
     struct stat st;
-    stat(path.c_str(), &st);
+    // Use lstat to avoid resolving symbolic links that we cannot watch anyway
+    // https://github.com/parcel-bundler/watcher/issues/76
+    lstat(path.c_str(), &st);
     DirEntry *entry = sub->tree->add(path, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
 
     if (entry->isDir) {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -384,7 +384,7 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'delete', path: f2}]);
         });
 
-        it.only('should not crash when a folder symlink is created', async () => {
+        it('should not crash when a folder symlink is created', async () => {
           let f1 = getFilename();
           let f2 = getFilename();
           fs.mkdir(f1);

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -383,6 +383,21 @@ describe('watcher', () => {
           let res = await nextEvent();
           assert.deepEqual(res, [{type: 'delete', path: f2}]);
         });
+
+        it.only('should not crash when a folder symlink is created', async () => {
+          let f1 = getFilename();
+          let f2 = getFilename();
+          fs.mkdir(f1);
+          await nextEvent();
+
+          fs.symlink(f1, f2);
+          await nextEvent();
+
+          fs.unlink(f2);
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'delete', path: f2 }]);
+        });
       });
 
       describe('rapid changes', () => {


### PR DESCRIPTION
It turns out that on Linux path handling is inconsistent between the initial `subscribe` call and when a new file/folder is added under a watched folder.

In the former case, watcher seems to not attempt to watch symbolic links because of `AT_SYMLINK_NOFOLLOW`

https://github.com/parcel-bundler/watcher/blob/7d88b1c8270befe2ce06b8ddbbfb37d26bb145ea/src/unix/legacy.cc#L42

However, in the latter case, a `stat` call will resolve a symlink and then `S_ISDIR` will return true even though it is a symbolic link. Only `lstat` will preserve the stat information of the link if it is a link.

https://github.com/parcel-bundler/watcher/blob/72a57be854f6a54fbb0c11ab99a1b148ec403ed8/src/linux/InotifyBackend.cc#L161-L163

**PS:** I found more locations of `stat` that maybe need a revisit and be changed to `lstat` but I didn't attempt to do that in this PR.

This PR fixes #76