### PR TITLE
Coalese delete and create events into update event

### DIFF
--- a/test/watcher.js
+++ b/test/watcher.js
@@ -525,8 +525,11 @@ describe('watcher', () => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
-                  setImmediate(() => resolve(events));
-                  await sub.unsubscribe();
+                  setImmediate(async () => {
+                    await sub.unsubscribe();
+
+                    resolve(events)
+                  });
                 },
                 {backend},
               );
@@ -559,8 +562,11 @@ describe('watcher', () => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
-                  setImmediate(() => resolve(events));
-                  await sub.unsubscribe();
+                  setImmediate(async () => {
+                    await sub.unsubscribe();
+
+                    resolve(events)
+                  });
                 },
                 {backend, ignore},
               );
@@ -599,8 +605,11 @@ describe('watcher', () => {
               let sub = await watcher.subscribe(
                 dir,
                 async (err, events) => {
-                  setImmediate(() => resolve(events));
-                  await sub.unsubscribe();
+                  setImmediate(async () => {
+                    await sub.unsubscribe();
+
+                    resolve(events)
+                  });
                 },
                 {backend},
               );

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,21 +410,19 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
-        if (backend !== 'watchman') {
-          it('should coalese delete and create events into update event', async () => {
-            let f1 = getFilename();
-            await fs.writeFile(f1, 'hello world');
+        it('should coalese delete and create events into update event', async () => {
+          let f1 = getFilename();
+          await fs.writeFile(f1, 'hello world');
 
-            let res = await nextEvent();
-            assert.deepEqual(res, [{ type: 'create', path: f1 }]);
+          let res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'create', path: f1 }]);
 
-            await fs.unlink(f1);
-            fs.writeFile(f1, 'hello world');
+          await fs.unlink(f1);
+          fs.writeFile(f1, 'hello world');
 
-            res = await nextEvent();
-            assert.deepEqual(res, [{ type: 'update', path: f1 }]);
-          });
-        }
+          res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+        });
 
         if (backend !== 'fs-events') {
           it('should ignore files that are created and deleted rapidly', async () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,19 +410,21 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
-        it('should coalese delete and create events into update event', async () => {
-          let f1 = getFilename();
-          await fs.writeFile(f1, 'hello world');
+        if (backend !== 'watchman') {
+          it('should coalese delete and create events into update event', async () => {
+            let f1 = getFilename();
+            await fs.writeFile(f1, 'hello world');
 
-          let res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'create', path: f1 }]);
+            let res = await nextEvent();
+            assert.deepEqual(res, [{ type: 'create', path: f1 }]);
 
-          await fs.unlink(f1);
-          fs.writeFile(f1, 'hello world');
+            await fs.unlink(f1);
+            fs.writeFile(f1, 'hello world');
 
-          res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
-        });
+            res = await nextEvent();
+            assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+          });
+        }
 
         if (backend !== 'fs-events') {
           it('should ignore files that are created and deleted rapidly', async () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -411,7 +411,7 @@ describe('watcher', () => {
         });
 
         if (backend !== 'watchman') {
-          it('should coalese delete and create events into update event', async () => {
+          it('should coalese delete and create events into single update event', async () => {
             let f1 = getFilename();
             await fs.writeFile(f1, 'hello world');
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,7 +410,7 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
-        it('should coalese delete and create events into single update event', async () => {
+        it('should coalese delete and create events into a single update event', async () => {
           let f1 = getFilename();
           await fs.writeFile(f1, 'hello world');
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,21 +410,19 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
-        if (backend !== 'watchman') {
-          it('should coalese delete and create events into single update event', async () => {
-            let f1 = getFilename();
-            await fs.writeFile(f1, 'hello world');
+        it('should coalese delete and create events into single update event', async () => {
+          let f1 = getFilename();
+          await fs.writeFile(f1, 'hello world');
 
-            let res = await nextEvent();
-            assert.deepEqual(res, [{ type: 'create', path: f1 }]);
+          let res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'create', path: f1 }]);
 
-            await fs.unlink(f1);
-            fs.writeFile(f1, 'hello world');
+          await fs.unlink(f1);
+          fs.writeFile(f1, 'hello world');
 
-            res = await nextEvent();
-            assert.deepEqual(res, [{ type: 'update', path: f1 }]);
-          });
-        }
+          res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+        });
 
         if (backend !== 'fs-events') {
           it('should ignore files that are created and deleted rapidly', async () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -425,9 +425,9 @@ describe('watcher', () => {
           await nextEvent();
 
           await fs.unlink(f1);
-          fs.writeFile(f1, 'hello world');
+          fs.writeFile(f1, 'hello world again');
 
-          res = await nextEvent();
+          let res = await nextEvent();
           assert.deepEqual(res, [{ type: 'update', path: f1 }]);
         });
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -416,6 +416,7 @@ describe('watcher', () => {
             // when rapidly deleting and creating a file so our event
             // coalescing is not working in that case
             // https://github.com/parcel-bundler/watcher/pull/84#issuecomment-981117725
+            // https://github.com/facebook/watchman/issues/980
             return;
           }
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,19 +410,19 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
-        it('should coalese delete and create events into a single update event', async () => {
-          let f1 = getFilename();
-          await fs.writeFile(f1, 'hello world');
+        if (backend !== 'watchman') { // watchman does not seem to support event coalescing on this level
+          it('should coalese delete and create events into a single update event', async () => {
+            let f1 = getFilename();
+            fs.writeFile(f1, 'hello world');
+            await nextEvent();
 
-          let res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'create', path: f1 }]);
+            await fs.unlink(f1);
+            fs.writeFile(f1, 'hello world');
 
-          await fs.unlink(f1);
-          fs.writeFile(f1, 'hello world');
-
-          res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
-        });
+            res = await nextEvent();
+            assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+          });
+        }
 
         if (backend !== 'fs-events') {
           it('should ignore files that are created and deleted rapidly', async () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -410,6 +410,20 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f1}]);
         });
 
+        it('should coalese delete and create events into update event', async () => {
+          let f1 = getFilename();
+          await fs.writeFile(f1, 'hello world');
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'create', path: f1 }]);
+
+          await fs.unlink(f1);
+          fs.writeFile(f1, 'hello world');
+
+          res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+        });
+
         if (backend !== 'fs-events') {
           it('should ignore files that are created and deleted rapidly', async () => {
             let f1 = getFilename();


### PR DESCRIPTION
This is my somewhat naive attempt to fix #72. When a `create` follows a `delete` during the debounce time, the event is coalesced to a `updated` type assuming that some external program (such as `git`) is rapidly changing the same file.

The tests seems to pass on Windows and Linux and even on macOS, except for the `watchman` backend. I would need some assistance to figure out why watchman behaves differently, I am even not fully sure how watchman tests can execute on my system where watchman is not installed.

**PS:** I noticed another suite of tests in `since.js` and wasn't sure if I should add my test there as well.