### PR TITLE
ignore failing `inotify_add_watch` unless explicitly asked to watch

### DIFF
--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -68,15 +68,18 @@ void InotifyBackend::subscribe(Watcher &watcher) {
   
   for (auto it = tree->entries.begin(); it != tree->entries.end(); it++) {
     if (it->second.isDir) {
-      watchDir(watcher, (DirEntry *)&it->second, tree);
+      bool success = watchDir(watcher, (DirEntry *)&it->second, tree);
+      if (!success) {
+        throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + strerror(errno), &watcher);
+      }
     }
   }
 }
 
-void InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree) {
+bool InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree) {
   int wd = inotify_add_watch(mInotify, entry->path.c_str(), INOTIFY_MASK);
   if (wd == -1) {
-    throw WatcherError(std::string("inotify_add_watch on '") + entry->path + std::string("' failed: ") + strerror(errno), &watcher);
+    return false;
   }
 
   std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>();
@@ -84,6 +87,8 @@ void InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr
   sub->entry = entry;
   sub->watcher = &watcher;
   mSubscriptions.emplace(wd, sub);
+
+  return true;
 }
 
 void InotifyBackend::handleEvents() {
@@ -165,7 +170,10 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
     DirEntry *entry = sub->tree->add(path, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
 
     if (entry->isDir) {
-      watchDir(*watcher, entry, sub->tree);
+      bool success = watchDir(*watcher, entry, sub->tree);
+      if (!success) {
+        sub->tree->remove(path);
+      }
     }
   } else if (event->mask & (IN_MODIFY | IN_ATTRIB)) {
     watcher->mEvents.update(path);

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -173,6 +173,7 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
       bool success = watchDir(*watcher, entry, sub->tree);
       if (!success) {
         sub->tree->remove(path);
+        return false;
       }
     }
   } else if (event->mask & (IN_MODIFY | IN_ATTRIB)) {

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -25,7 +25,7 @@ private:
   std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
   Signal mEndedSignal;
 
-  void watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree);
+  bool watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree);
   void handleEvents();
   void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
   bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -472,22 +472,24 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'delete', path: f1}]);
         });
 
-        it('should not crash with rapid folder creates and deletes', async () => {
-          let f1 = getFilename();
-          let f2 = getFilename();
-
-          for (let i = 0; i < 1000; i++) {
-            await fs.mkdir(f1);
-            await fs.rmdir(f1);
-          }
-
-          await nextEvent();
-
-          fs.writeFile(f2, 'hello world');
-
-          let res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'create', path: f2 }]);
-        });
+        if (process.platform === 'linux') {
+          it('linux: should not crash with rapid folder creates and deletes', async () => {
+            let f1 = getFilename();
+            let f2 = getFilename();
+  
+            for (let i = 0; i < 1000; i++) {
+              await fs.mkdir(f1);
+              await fs.rmdir(f1);
+            }
+  
+            await nextEvent();
+  
+            fs.writeFile(f2, 'hello world');
+  
+            let res = await nextEvent();
+            assert.deepEqual(res, [{ type: 'create', path: f2 }]);
+          });
+        }
       });
 
       describe('ignore', () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -476,16 +476,16 @@ describe('watcher', () => {
           it('linux: should not crash with rapid folder creates and deletes', async () => {
             let f1 = getFilename();
             let f2 = getFilename();
-  
+
             for (let i = 0; i < 1000; i++) {
               await fs.mkdir(f1);
               await fs.rmdir(f1);
             }
-  
+
             await nextEvent();
-  
+
             fs.writeFile(f2, 'hello world');
-  
+
             let res = await nextEvent();
             assert.deepEqual(res, [{ type: 'create', path: f2 }]);
           });

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -471,6 +471,22 @@ describe('watcher', () => {
           let res = await nextEvent();
           assert.deepEqual(res, [{type: 'delete', path: f1}]);
         });
+
+        it('should not crash with rapid folder creates and deletes', async () => {
+          let f1 = getFilename();
+
+          for (let i = 0; i < 1000; i++) {
+            await fs.mkdir(f1);
+            await fs.rmdir(f1);
+          }
+
+          let f2 = getFilename();
+
+          fs.writeFile(f2, 'hello world');
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [{ type: 'create', path: f2 }]);
+        });
       });
 
       describe('ignore', () => {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -474,13 +474,14 @@ describe('watcher', () => {
 
         it('should not crash with rapid folder creates and deletes', async () => {
           let f1 = getFilename();
+          let f2 = getFilename();
 
           for (let i = 0; i < 1000; i++) {
             await fs.mkdir(f1);
             await fs.rmdir(f1);
           }
 
-          let f2 = getFilename();
+          await nextEvent();
 
           fs.writeFile(f2, 'hello world');
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -477,7 +477,7 @@ describe('watcher', () => {
             let f1 = getFilename();
             let f2 = getFilename();
 
-            for (let i = 0; i < 1000; i++) {
+            for (let i = 0; i < 100; i++) {
               await fs.mkdir(f1);
               await fs.rmdir(f1);
             }

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -471,25 +471,6 @@ describe('watcher', () => {
           let res = await nextEvent();
           assert.deepEqual(res, [{type: 'delete', path: f1}]);
         });
-
-        if (process.platform === 'linux') {
-          it('linux: should not crash with rapid folder creates and deletes', async () => {
-            let f1 = getFilename();
-            let f2 = getFilename();
-
-            for (let i = 0; i < 100; i++) {
-              await fs.mkdir(f1);
-              await fs.rmdir(f1);
-            }
-
-            await nextEvent();
-
-            fs.writeFile(f2, 'hello world');
-
-            let res = await nextEvent();
-            assert.deepEqual(res, [{ type: 'create', path: f2 }]);
-          });
-        }
       });
 
       describe('ignore', () => {


### PR DESCRIPTION
This PR fixes #85 by gracefully handling failing `inotify_add_watch` calls instead of terminating.