### PR TITLE
fix: Directly store inotify subscription paths 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ All of the APIs in `@parcel/watcher` support the following options, which are pa
 
 ## Who is using this?
 
-* [Parcel 2](https://parceljs.org/)
-* [VSCode](https://code.visualstudio.com/updates/v1_62#_file-watching-changes)
-* [Tailwind CSS Intellisense](https://github.com/tailwindlabs/tailwindcss-intellisense)
-* [Gatsby Cloud](https://twitter.com/chatsidhartha/status/1435647412828196867)
-* [Nx](https://nx.dev)
+- [Parcel 2](https://parceljs.org/)
+- [VSCode](https://code.visualstudio.com/updates/v1_62#_file-watching-changes)
+- [Tailwind CSS Intellisense](https://github.com/tailwindlabs/tailwindcss-intellisense)
+- [Gatsby Cloud](https://twitter.com/chatsidhartha/status/1435647412828196867)
+- [Nx](https://nx.dev)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 function normalizeOptions(dir, opts = {}) {
   if (Array.isArray(opts.ignore)) {
     opts = Object.assign({}, opts, {
-      ignore: opts.ignore.map(ignore => path.resolve(dir, ignore)),
+      ignore: opts.ignore.map((ignore) => path.resolve(dir, ignore)),
     });
   }
 

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -65,10 +65,10 @@ InotifyBackend::~InotifyBackend() {
 void InotifyBackend::subscribe(Watcher &watcher) {
   // Build a full directory tree recursively, and watch each directory.
   std::shared_ptr<DirTree> tree = getTree(watcher);
-  
+
   for (auto it = tree->entries.begin(); it != tree->entries.end(); it++) {
     if (it->second.isDir) {
-      bool success = watchDir(watcher, (DirEntry *)&it->second, tree);
+      bool success = watchDir(watcher, it->second.path, tree);
       if (!success) {
         throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + strerror(errno), &watcher);
       }
@@ -76,15 +76,15 @@ void InotifyBackend::subscribe(Watcher &watcher) {
   }
 }
 
-bool InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree) {
-  int wd = inotify_add_watch(mInotify, entry->path.c_str(), INOTIFY_MASK);
+bool InotifyBackend::watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree) {
+  int wd = inotify_add_watch(mInotify, path.c_str(), INOTIFY_MASK);
   if (wd == -1) {
     return false;
   }
 
   std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>();
   sub->tree = tree;
-  sub->entry = entry;
+  sub->path = path;
   sub->watcher = &watcher;
   mSubscriptions.emplace(wd, sub);
 
@@ -149,8 +149,10 @@ void InotifyBackend::handleEvent(struct inotify_event *event, std::unordered_set
 bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub) {
   // Build full path and check if its in our ignore list.
   Watcher *watcher = sub->watcher;
-  std::string path = std::string(sub->entry->path);
-  if (event->len > 0) { 
+  std::string path = std::string(sub->path);
+  bool isDir = event->mask & IN_ISDIR;
+
+  if (event->len > 0) {
     path += "/" + std::string(event->name);
   }
 
@@ -170,7 +172,7 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
     DirEntry *entry = sub->tree->add(path, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
 
     if (entry->isDir) {
-      bool success = watchDir(*watcher, entry, sub->tree);
+      bool success = watchDir(*watcher, path, sub->tree);
       if (!success) {
         sub->tree->remove(path);
         return false;
@@ -183,18 +185,20 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
     stat(path.c_str(), &st);
     sub->tree->update(path, CONVERT_TIME(st.st_mtim));
   } else if (event->mask & (IN_DELETE | IN_DELETE_SELF | IN_MOVED_FROM | IN_MOVE_SELF)) {
+    bool isSelfEvent = (event->mask & (IN_DELETE_SELF | IN_MOVE_SELF));
     // Ignore delete/move self events unless this is the recursive watch root
-    if ((event->mask & (IN_DELETE_SELF | IN_MOVE_SELF)) && path != watcher->mDir) {
+    if (isSelfEvent && path != watcher->mDir) {
       return false;
     }
 
     // If the entry being deleted/moved is a directory, remove it from the list of subscriptions
-    auto entry = sub->tree->find(path);
-    if (entry && entry->isDir) {
-      for (auto it = mSubscriptions.begin(); it != mSubscriptions.end(); it++) {
-        if (it->second->entry == &*entry) {
-          mSubscriptions.erase(it);
-          break;
+    // XXX: self events don't have the IN_ISDIR mask
+    if (isSelfEvent || isDir) {
+      for (auto it = mSubscriptions.begin(); it != mSubscriptions.end();) {
+        if (it->second->path == path) {
+          it = mSubscriptions.erase(it);
+        } else {
+          ++it;
         }
       }
     }

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -9,7 +9,7 @@
 
 struct InotifySubscription {
   std::shared_ptr<DirTree> tree;
-  DirEntry *entry;
+  std::string path;
   Watcher *watcher;
 };
 
@@ -25,7 +25,7 @@ private:
   std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
   Signal mEndedSignal;
 
-  bool watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree);
+  bool watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree);
   void handleEvents();
   void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
   bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);

--- a/test/since.js
+++ b/test/since.js
@@ -6,9 +6,7 @@ const path = require('path');
 const snapshotPath = path.join(__dirname, 'snapshot.txt');
 const tmpDir = path.join(
   fs.realpathSync(require('os').tmpdir()),
-  Math.random()
-    .toString(31)
-    .slice(2),
+  Math.random().toString(31).slice(2),
 );
 fs.mkdirpSync(tmpDir);
 
@@ -23,13 +21,7 @@ if (process.platform === 'darwin') {
 
 let c = 0;
 const getFilename = (...dir) =>
-  path.join(
-    tmpDir,
-    ...dir,
-    `test${c++}${Math.random()
-      .toString(31)
-      .slice(2)}`,
-  );
+  path.join(tmpDir, ...dir, `test${c++}${Math.random().toString(31).slice(2)}`);
 
 function testPrecision() {
   let f = getFilename();
@@ -41,7 +33,7 @@ function testPrecision() {
 const isSecondPrecision = testPrecision();
 
 describe('since', () => {
-  const sleep = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms));
+  const sleep = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms));
 
   before(async () => {
     // wait for tmp dir to be created.
@@ -54,7 +46,7 @@ describe('since', () => {
     } catch (err) {}
   });
 
-  backends.forEach(backend => {
+  backends.forEach((backend) => {
     describe(backend, () => {
       describe('files', () => {
         it('should emit when a file is created', async () => {
@@ -518,9 +510,7 @@ describe('since', () => {
         it('should error if the watched directory does not exist', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
 
           let threw = false;
@@ -541,9 +531,7 @@ describe('since', () => {
 
           let file = path.join(
             fs.realpathSync(require('os').tmpdir()),
-            Math.random()
-              .toString(31)
-              .slice(2),
+            Math.random().toString(31).slice(2),
           );
           fs.writeFileSync(file, 'test');
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -204,8 +204,8 @@ describe('watcher', () => {
 
             fs.mkdirp(dir);
             res = await Promise.race([
-              new Promise(resolve => setTimeout(resolve, 100)),
-              nextEvent()
+              new Promise((resolve) => setTimeout(resolve, 100)),
+              nextEvent(),
             ]);
             assert.equal(res, undefined);
           } finally {
@@ -396,7 +396,7 @@ describe('watcher', () => {
           fs.unlink(f2);
 
           let res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'delete', path: f2 }]);
+          assert.deepEqual(res, [{type: 'delete', path: f2}]);
         });
       });
 
@@ -428,7 +428,7 @@ describe('watcher', () => {
           fs.writeFile(f1, 'hello world again');
 
           let res = await nextEvent();
-          assert.deepEqual(res, [{ type: 'update', path: f1 }]);
+          assert.deepEqual(res, [{type: 'update', path: f1}]);
         });
 
         if (backend !== 'fs-events') {
@@ -535,7 +535,7 @@ describe('watcher', () => {
                   setImmediate(async () => {
                     await sub.unsubscribe();
 
-                    resolve(events)
+                    resolve(events);
                   });
                 },
                 {backend},
@@ -572,7 +572,7 @@ describe('watcher', () => {
                   setImmediate(async () => {
                     await sub.unsubscribe();
 
-                    resolve(events)
+                    resolve(events);
                   });
                 },
                 {backend, ignore},
@@ -615,7 +615,7 @@ describe('watcher', () => {
                   setImmediate(async () => {
                     await sub.unsubscribe();
 
-                    resolve(events)
+                    resolve(events);
                   });
                 },
                 {backend},


### PR DESCRIPTION
This fixes segmentations faults on Linux when using inotify and
renaming both a directory (a.k.a the `parent`) and one of its
sub-directories (a.k.a. the `children`).

When watching a new directory, the InotifyBackend will store a pointer
to this directory's DirEntry to have access to its path.
Also, when a directory is deleted, its DirEntry is erased as well as
its content's entries.
Finally, the InotifyBackend treats moves as a combination of a
deletion and a creation, both in terms of events and entries.

Therefore, when processing a `parent` move followed by a `child`
renaming, the InotifyBackend will follow these steps:

  1. process the `parent` deletion by removing its subscription, its
     associated DirEntry and the `child` DirEntry
  2. process the `parent` creation at its new path by creating a new
     subscription and a new DirEntry
  3. try to process the `child` deletion and crash because its
     associated DirEntry does not exist anymore and thus its pointer
     in the subscription cannot be dereferenced

We could prevent the segmentation fault by removing the `children`'s
subscriptions with the `parent` one when processing the`parent`
deletion but this would mean missing the `child` renaming.

In the end, we solve the issue by directly storing the watched
directory's path in the subscription rather than a pointer to a
DirEntry. By doing so, even when the `child` DirEntry is deleted, the
subscription for this directory will have access to its path and be
able to process inotify events.