### PR TITLE
Improve support for mounted file systems on macOS

### DIFF
--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -126,7 +126,8 @@ void FSEventsCallback(
       uint64_t ctime = CONVERT_TIME(file.st_birthtimespec);
       uint64_t mtime = CONVERT_TIME(file.st_mtimespec);
       auto existed = !since && state->tree->find(paths[i]);
-      if (isModified && (existed || ctime <= since)) {
+      // Some mounted file systems report a creation time of 0/unix epoch which we special case.
+      if (isModified && (existed || (ctime <= since && ctime != 0))) {
         state->tree->update(paths[i], mtime);
         list->update(paths[i]);
       } else {


### PR DESCRIPTION
Some mounted file systems report a creation time of 0 - we want to support these systems reporting a file as created and modified and properly treat it as created.