### PR TITLE
Update debounce logic

### DIFF
--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -162,7 +162,7 @@ void checkWatcher(Watcher &watcher) {
 void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
   checkWatcher(watcher);
 
-  CFAbsoluteTime latency = 0.01;
+  CFAbsoluteTime latency = 0.001;
   CFStringRef fileWatchPath = CFStringCreateWithCString(
     NULL,
     watcher.mDir.c_str(),


### PR DESCRIPTION
This updates the debouncing logic to fix two issues:

* When changing only a single file, there was a minimum of 50ms of latency. We waited in case there were more future changes to batch. In order to optimize the common case of changing only a single file at a time, we now report the first event immediately, and batch subsequent events as before.
* As reported in #70, it was possible to never receive any events at all for a rapidly changing file (under the 50ms threshold) because we were always waiting for more. Now, we always emit at least one event every 500ms. Not sure if this threshold is too high, but I'd like to avoid triggering a Parcel build too often, for example while running a package manager.