### PR TITLE
Ignore duplicate events from FSEvents for the same mtime

### DIFF
--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -109,9 +109,11 @@ void FSEventsCallback(
       
       // Ignore if mtime is the same as the last event.
       // This prevents duplicate events from being emitted.
+      // If tv_nsec is zero, the file system probably only has second-level
+      // granularity so allow the even through in that case.
       uint64_t mtime = CONVERT_TIME(file.st_mtimespec);
       DirEntry *entry = state->tree->find(paths[i]);
-      if (entry && mtime == entry->mtime) {
+      if (entry && mtime == entry->mtime && file.st_mtimespec.tv_nsec != 0) {
         continue;
       }
 
@@ -146,7 +148,7 @@ void FSEventsCallback(
       uint64_t ctime = CONVERT_TIME(file.st_birthtimespec);
       uint64_t mtime = CONVERT_TIME(file.st_mtimespec);
       DirEntry *entry = !since ? state->tree->find(paths[i]) : NULL;
-      if (entry && entry->mtime == mtime) {
+      if (entry && entry->mtime == mtime && file.st_mtimespec.tv_nsec != 0) {
         continue;
       }
       

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -102,7 +102,27 @@ void FSEventsCallback(
         deletedRoot = true;
       }
     } else if (isModified && !(isCreated || isRemoved || isRenamed)) {
-      state->tree->update(paths[i], 0);
+      struct stat file;
+      if (stat(paths[i], &file)) {
+        continue;
+      }
+      
+      // Ignore if mtime is the same as the last event.
+      // This prevents duplicate events from being emitted.
+      uint64_t mtime = CONVERT_TIME(file.st_mtimespec);
+      DirEntry *entry = state->tree->find(paths[i]);
+      if (entry && mtime == entry->mtime) {
+        continue;
+      }
+
+      if (entry) {
+        // Update mtime.
+        entry->mtime = mtime;
+      } else {
+        // Add to tree if this path has not been discovered yet.
+        state->tree->add(paths[i], mtime, S_ISDIR(file.st_mode));
+      }
+
       list->update(paths[i]);
     } else {
       // If multiple flags were set, then we need to call `stat` to determine if the file really exists.
@@ -125,9 +145,13 @@ void FSEventsCallback(
       // If the file was modified, and existed before, then this is an update, otherwise a create.
       uint64_t ctime = CONVERT_TIME(file.st_birthtimespec);
       uint64_t mtime = CONVERT_TIME(file.st_mtimespec);
-      auto existed = !since && state->tree->find(paths[i]);
+      DirEntry *entry = !since ? state->tree->find(paths[i]) : NULL;
+      if (entry && entry->mtime == mtime) {
+        continue;
+      }
+      
       // Some mounted file systems report a creation time of 0/unix epoch which we special case.
-      if (isModified && (existed || (ctime <= since && ctime != 0))) {
+      if (isModified && (entry || (ctime <= since && ctime != 0))) {
         state->tree->update(paths[i], mtime);
         list->update(paths[i]);
       } else {


### PR DESCRIPTION
When saving a file in VSCode, FSEvents sends two separate events. One with the `kFSEventStreamEventFlagItemInodeMetaMod` flag, and a second one additionally with `kFSEventStreamEventFlagItemModified`. These flags are not reliable. If another change happened in the last 30 seconds or so, other flags may be mixed together. Related issues: https://github.com/microsoft/vscode/issues/9419, https://github.com/nodejs/node/issues/6112.

Prior to #113, these events were debounced and emitted as a single update to JS. But we don't want to wait before sending events, especially since the delay between these two FSEvents is unknown. This PR stores the `mtime` of the file in our tree, and compares it with the current `mtime` when a new event comes in. If they are the same, the event is ignored.