### PR TITLE
fix: Prevent directory locking on Windows

### DIFF
--- a/src/windows/WindowsBackend.cc
+++ b/src/windows/WindowsBackend.cc
@@ -1,5 +1,4 @@
 #include <string>
-#include <sstream>
 #include <stack>
 #include "../DirTree.hh"
 #include "../shared/BruteForceBackend.hh"
@@ -11,12 +10,13 @@
 #define CONVERT_TIME(ft) ULARGE_INTEGER{ft.dwLowDateTime, ft.dwHighDateTime}.QuadPart
 
 void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
-  HANDLE hFind = INVALID_HANDLE_VALUE;
   std::stack<std::string> directories;
-  
+
   directories.push(watcher.mDir);
 
   while (!directories.empty()) {
+    HANDLE hFind = INVALID_HANDLE_VALUE;
+
     std::string path = directories.top();
     std::string spec = path + "\\*";
     directories.pop();
@@ -29,7 +29,7 @@ void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree
         FindClose(hFind);
         throw WatcherError("Error opening directory", &watcher);
       }
-      
+
       tree->remove(path);
       continue;
     }
@@ -47,9 +47,9 @@ void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree
         }
       }
     } while (FindNextFile(hFind, &ffd) != 0);
-  }
 
-  FindClose(hFind);
+    FindClose(hFind);
+  }
 }
 
 void WindowsBackend::start() {
@@ -163,7 +163,7 @@ public:
     if (!mRunning) {
       return;
     }
-    
+
     switch (errorCode) {
       case ERROR_OPERATION_ABORTED:
         return;


### PR DESCRIPTION
  On Windows, when opening a file handle for a directory, this directory
  is locked to prevent some actions like renaming it. The lock is
  released once the handle is closed.

  When reading the content of a directory we've subscribed to, we open
  search handles for every subdirectory but only close the one that was
  opened last.
  Therefore, we end up with some directories being locked until the
  process is terminated.

  Closing each search handle once we're done using it (i.e. we've read
  the content of the associated directory) allows Windows to release the
  associated lock and prevents blocking other software from manipulating
  the directories.

  NB: I could not create a test showcasing the lock issue but it can be
  manually reproduced with the following steps:

  1. Create the following hierarchy: `base/` `base/dir/` `base/dir/subdir/` `base/dir/subdir/file.txt`
  2. Create a simple Node JS script subscribing to `base/` with @parcel/watcher
  3. Open `base/` with the Windows File Explorer
  4. Try to rename `dir/` into `dir2/`

  -> Without the fix, the File Explorer will display an error message
  telling you the operation cannot be performed as the folder is already
  in use by another software
  -> With the fix, the rename operation is performed without issues