### PR TITLE
fix: Handle utf-8 file paths on Windows

### DIFF
--- a/src/windows/win_utils.cc
+++ b/src/windows/win_utils.cc
@@ -19,9 +19,13 @@ std::string utf16ToUtf8(const WCHAR *input, size_t length) {
   return res;
 }
 
-std::string normalizePath(std::string path) {
+std::wstring extendedWidePath(std::string path) {
   // Prevent truncation to MAX_PATH characters by adding the \\?\ prefix
-  std::wstring p = utf8ToUtf16("\\\\?\\" + path);
+  return utf8ToUtf16("\\\\?\\" + path);
+}
+
+std::string normalizePath(std::string path) {
+  std::wstring p = extendedWidePath(path);
 
   // Get the required length for the output
   unsigned int len = GetLongPathNameW(p.data(), NULL, 0);

--- a/src/windows/win_utils.hh
+++ b/src/windows/win_utils.hh
@@ -6,6 +6,7 @@
 
 std::wstring utf8ToUtf16(std::string input);
 std::string utf16ToUtf8(const WCHAR *input, size_t length);
+std::wstring extendedWidePath(std::string path);
 std::string normalizePath(std::string path);
 
 #endif


### PR DESCRIPTION
  Although the WindowsBackend uses unicode aware Windows file API
  functions when processing events, it does not do so when searching
  directories and their content when creating a new Subscription.
  This results in invalid file paths stored in the subscription's tree
  when the file name contains non-ascii UTF-8 characters and thus,
  dropped events when they rely on the existance of a dir entry with the
  valid path.

  e.g. consider, we have a directory `dir/`, containing a file ``

    1. Create the following hierarchy: `dir/` `dir/spécial` (i.e. the 3rd letter of the file name is a French e-acute)
    2. Subscribe to `dir/` 3. Delete the file `spécial`

    -> no events will be notified for the deletion because the file path
    can't be found in the subscription tree

  Using unicode aware search functions in BruteForceBackend::readTree
  solves this.