### PR TITLE
Add FreeBSD support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -66,6 +66,17 @@
               "ExceptionHandling": 1,  # /EHsc
             }
           }
+        }],
+        ['OS=="freebsd"', {
+          "sources": [
+            "src/watchman/BSER.cc",
+            "src/watchman/WatchmanBackend.cc",
+            "src/shared/BruteForceBackend.cc",
+          ],
+          "defines": [
+            "WATCHMAN",
+            "BRUTE_FORCE"
+          ]
         }]
       ]
     }


### PR DESCRIPTION
Currently only watchman and brute force backends are available. Fixing #127.