### PR TITLE
Add support for android, to build on termux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,7 +34,7 @@
             "ARCHS": ["arm64"]
           }
         }],
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="android"', {
           "sources": [
             "src/watchman/BSER.cc",
             "src/watchman/WatchmanBackend.cc",


### PR DESCRIPTION
fix the same issue mentioned at https://github.com/parcel-bundler/watcher/issues/127