### PR TITLE
Add support for android, to build on termux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,7 +34,7 @@
             "ARCHS": ["arm64"]
           }
         }],
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="android"', {
           "sources": [
             "src/watchman/BSER.cc",
             "src/watchman/WatchmanBackend.cc",


### PR DESCRIPTION
Fix issue [Undefined symbol "_ZTV17BruteForceBackend"](https://github.com/parcel-bundler/watcher/issues/127) that happens on termux