### PR TITLE
Migrate to napi threadsafe functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/watcher",
-  "version": "2.2.0",
+  "version": "2.2.1-alpha.0",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {

--- a/src/Watcher.cc
+++ b/src/Watcher.cc
@@ -137,9 +137,9 @@ bool Watcher::watch(Function callback) {
   );
 
   mCallbacks.push_back(Callback {
-    .tsfn = tsfn,
-    .ref = Napi::Persistent(callback),
-    .threadId = std::this_thread::get_id()
+    tsfn,
+    Napi::Persistent(callback),
+    std::this_thread::get_id()
   });
 
   return true;

--- a/src/Watcher.hh
+++ b/src/Watcher.hh
@@ -5,7 +5,6 @@
 #include <unordered_set>
 #include <set>
 #include <node_api.h>
-#include <sys/stat.h>
 #include "Glob.hh"
 #include "Event.hh"
 #include "Debounce.hh"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -31,7 +31,7 @@ std::unordered_set<std::string> getIgnorePaths(Env env, Value opts) {
 
 std::unordered_set<Glob> getIgnoreGlobs(Env env, Value opts) {
   std::unordered_set<Glob> result;
-  
+
   if (opts.IsObject()) {
     Value v = opts.As<Object>().Get(String::New(env, "ignoreGlobs"));
     if (v.IsArray()) {
@@ -165,7 +165,7 @@ public:
     );
 
     backend = getBackend(env, opts);
-    callback = Persistent(fn.As<Function>());
+    watcher->watch(fn.As<Function>());
   }
 
 private:
@@ -174,8 +174,12 @@ private:
   FunctionReference callback;
 
   void execute() override {
-    backend->watch(*watcher);
-    watcher->watch(std::move(callback));
+    try {
+      backend->watch(*watcher);
+    } catch (std::exception &err) {
+      watcher->destroy();
+      throw;
+    }
   }
 };
 

--- a/src/kqueue/KqueueBackend.cc
+++ b/src/kqueue/KqueueBackend.cc
@@ -207,6 +207,11 @@ bool KqueueBackend::compareDir(int fd, std::string &path, std::unordered_set<Wat
   std::vector<KqueueSubscription *> subs = findSubscriptions(path);
   std::string dirStart = path + DIR_SEP;
 
+  std::unordered_set<std::shared_ptr<DirTree>> trees;
+  for (auto it = subs.begin(); it != subs.end(); it++) {
+    trees.emplace((*it)->tree);
+  }
+
   std::unordered_set<std::string> entries;
   struct dirent *entry;
   while ((entry = readdir(dir))) {
@@ -217,39 +222,55 @@ bool KqueueBackend::compareDir(int fd, std::string &path, std::unordered_set<Wat
     std::string fullpath = dirStart + entry->d_name;
     entries.emplace(fullpath);
 
-    for (auto it = subs.begin(); it != subs.end(); it++) {
-      KqueueSubscription *sub = *it;
-      if (sub->watcher->isIgnored(fullpath)) {
-        continue;
-      }
-
-      if (!sub->tree->find(fullpath)) {
+    for (auto it = trees.begin(); it != trees.end(); it++) {
+      std::shared_ptr<DirTree> tree = *it;
+      if (!tree->find(fullpath)) {
         struct stat st;
         fstatat(fd, entry->d_name, &st, AT_SYMLINK_NOFOLLOW);
-        sub->tree->add(fullpath, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
-        sub->watcher->mEvents.create(fullpath);
-        watchers.emplace(sub->watcher);
+        tree->add(fullpath, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
 
-        bool success = watchDir(*sub->watcher, fullpath, sub->tree);
-        if (!success) {
-          sub->tree->remove(fullpath);
-          return false;
+        // Notify all watchers with the same tree.
+        for (auto i = subs.begin(); i != subs.end(); i++) {
+          KqueueSubscription *sub = *i;
+          if (sub->tree == tree) {
+            if (sub->watcher->isIgnored(fullpath)) {
+              continue;
+            }
+
+            sub->watcher->mEvents.create(fullpath);
+            watchers.emplace(sub->watcher);
+
+            bool success = watchDir(*sub->watcher, fullpath, sub->tree);
+            if (!success) {
+              sub->tree->remove(fullpath);
+              return false;
+            }
+          }
         }
       }
     }
   }
 
-  for (auto it = subs.begin(); it != subs.end(); it++) {
-    KqueueSubscription *sub = *it;
-    for (auto it = sub->tree->entries.begin(); it != sub->tree->entries.end();) {
-      if (it->first.rfind(dirStart, 0) == 0 && entries.count(it->first) == 0) {
-        sub->watcher->mEvents.remove(it->first);
-        watchers.emplace(sub->watcher);
-        mFdToEntry.erase((int)(size_t)it->second.state);
-        mSubscriptions.erase(it->first);
-        it = sub->tree->entries.erase(it);
+  for (auto it = trees.begin(); it != trees.end(); it++) {
+    std::shared_ptr<DirTree> tree = *it;
+    for (auto entry = tree->entries.begin(); entry != tree->entries.end();) {
+      if (entry->first.rfind(dirStart, 0) == 0 && entries.count(entry->first) == 0) {
+        // Notify all watchers with the same tree.
+        for (auto i = subs.begin(); i != subs.end(); i++) {
+          if ((*i)->tree == tree) {
+            KqueueSubscription *sub = *i;
+            if (!sub->watcher->isIgnored(entry->first)) {
+              sub->watcher->mEvents.remove(entry->first);
+              watchers.emplace(sub->watcher);
+            }
+          }
+        }
+
+        mFdToEntry.erase((int)(size_t)entry->second.state);
+        mSubscriptions.erase(entry->first);
+        entry = tree->entries.erase(entry);
       } else {
-        it++;
+        entry++;
       }
     }
   }

--- a/src/kqueue/KqueueBackend.cc
+++ b/src/kqueue/KqueueBackend.cc
@@ -2,6 +2,9 @@
 #include <poll.h>
 #include <unistd.h>
 #include <libgen.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include "KqueueBackend.hh"
 
 #if __APPLE__

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -1,6 +1,7 @@
 #include <memory>
 #include <poll.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include "InotifyBackend.hh"
 
 #define INOTIFY_MASK \

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -2,6 +2,7 @@
 #include <poll.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include "InotifyBackend.hh"
 
 #define INOTIFY_MASK \

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -106,7 +106,7 @@ void FSEventsCallback(
       if (stat(paths[i], &file)) {
         continue;
       }
-      
+
       // Ignore if mtime is the same as the last event.
       // This prevents duplicate events from being emitted.
       // If tv_nsec is zero, the file system probably only has second-level
@@ -151,7 +151,7 @@ void FSEventsCallback(
       if (entry && entry->mtime == mtime && file.st_mtimespec.tv_nsec != 0) {
         continue;
       }
-      
+
       // Some mounted file systems report a creation time of 0/unix epoch which we special case.
       if (isModified && (entry || (ctime <= since && ctime != 0))) {
         state->tree->update(paths[i], mtime);
@@ -163,9 +163,7 @@ void FSEventsCallback(
     }
   }
 
-  if (watcher->mWatched) {
-    watcher->notify();
-  }
+  watcher->notify();
 
   // Stop watching if the root directory was deleted.
   if (deletedRoot) {

--- a/src/unix/fts.cc
+++ b/src/unix/fts.cc
@@ -7,6 +7,7 @@
 #define __THROW
 
 #include <fts.h>
+#include <sys/stat.h>
 #include "../DirTree.hh"
 #include "../shared/BruteForceBackend.hh"
 

--- a/src/unix/legacy.cc
+++ b/src/unix/legacy.cc
@@ -13,6 +13,7 @@
 #endif
 #include <dirent.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "../DirTree.hh"
 #include "../shared/BruteForceBackend.hh"

--- a/src/watchman/IPC.hh
+++ b/src/watchman/IPC.hh
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
+#include <winsock2.h>
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -19,12 +20,12 @@ public:
     #ifdef _WIN32
       while (true) {
         mPipe = CreateFile(
-          path.data(), // pipe name 
-          GENERIC_READ | GENERIC_WRITE, // read and write access 
-          0, // no sharing 
+          path.data(), // pipe name
+          GENERIC_READ | GENERIC_WRITE, // read and write access
+          0, // no sharing
           NULL, // default security attributes
-          OPEN_EXISTING, // opens existing pipe 
-          FILE_FLAG_OVERLAPPED, // attributes 
+          OPEN_EXISTING, // opens existing pipe
+          FILE_FLAG_OVERLAPPED, // attributes
           NULL // no template file
         );
 
@@ -74,11 +75,11 @@ public:
       OVERLAPPED overlapped;
       overlapped.hEvent = mWriter;
       bool success = WriteFile(
-        mPipe, // pipe handle 
-        buf.data(), // message 
-        buf.size(), // message length 
-        NULL, // bytes written 
-        &overlapped // overlapped 
+        mPipe, // pipe handle
+        buf.data(), // message
+        buf.size(), // message length
+        NULL, // bytes written
+        &overlapped // overlapped
       );
 
       if (mStopped) {
@@ -122,11 +123,11 @@ public:
       OVERLAPPED overlapped;
       overlapped.hEvent = mReader;
       bool success = ReadFile(
-        mPipe, // pipe handle 
-        buf, // buffer to receive reply 
-        len, // size of buffer 
-        NULL, // number of bytes read 
-        &overlapped // overlapped 
+        mPipe, // pipe handle
+        buf, // buffer to receive reply
+        len, // size of buffer
+        NULL, // number of bytes read
+        &overlapped // overlapped
       );
 
       if (!success && !mStopped) {
@@ -140,7 +141,7 @@ public:
       if (!success && !mStopped) {
         throw std::runtime_error("GetOverlappedResult failed");
       }
-      
+
       return read;
     #else
       int r = ::read(mSock, buf, len);

--- a/src/watchman/WatchmanBackend.cc
+++ b/src/watchman/WatchmanBackend.cc
@@ -13,6 +13,7 @@
 #define popen _popen
 #define pclose _pclose
 #else
+#include <sys/stat.h>
 #define normalizePath(dir) dir
 #endif
 
@@ -53,7 +54,7 @@ std::string getSockPath() {
   BSER b = readBSER([fp] (char *buf, size_t len) {
     return fread(buf, sizeof(char), len, fp);
   });
-  
+
   pclose(fp);
 
   auto objValue = b.objectValue();
@@ -113,7 +114,7 @@ void handleFiles(Watcher &watcher, BSER::Object obj) {
   if (found == obj.end()) {
     throw WatcherError("Error reading changes from watchman", &watcher);
   }
-  
+
   auto files = found->second.arrayValue();
   for (auto it = files.begin(); it != files.end(); it++) {
     auto file = it->objectValue();
@@ -325,7 +326,7 @@ void WatchmanBackend::subscribe(Watcher &watcher) {
 void WatchmanBackend::unsubscribe(Watcher &watcher) {
   std::string id = getId(watcher);
   auto erased = mSubscriptions.erase(id);
-  
+
   if (erased) {
     BSER::Array cmd;
     cmd.push_back("unsubscribe");

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -556,7 +556,7 @@ describe('watcher', () => {
         });
       });
 
-      describe.skip('multiple', () => {
+      describe('multiple', () => {
         it('should support multiple watchers for the same directory', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -556,45 +556,7 @@ describe('watcher', () => {
         });
       });
 
-      describe('ignore', () => {
-        it('should ignore a directory', async () => {
-          let f1 = getFilename();
-          let f2 = getFilename(path.basename(ignoreDir));
-          await fs.mkdir(ignoreDir);
-
-          fs.writeFile(f1, 'hello');
-          fs.writeFile(f2, 'sup');
-
-          let res = await nextEvent();
-          assert.deepEqual(res, [{type: 'create', path: f1}]);
-        });
-
-        it('should ignore a file', async () => {
-          let f1 = getFilename();
-
-          fs.writeFile(f1, 'hello');
-          fs.writeFile(ignoreFile, 'sup');
-
-          let res = await nextEvent();
-          assert.deepEqual(res, [{type: 'create', path: f1}]);
-        });
-
-        it('should ignore globs', async () => {
-          fs.writeFile(path.join(ignoreGlobDir, 'test.txt'), 'hello');
-          fs.writeFile(path.join(ignoreGlobDir, 'test.ignore'), 'hello');
-          fs.writeFile(path.join(ignoreGlobDir, 'ignore', 'test.txt'), 'hello');
-          fs.writeFile(path.join(ignoreGlobDir, 'ignore', 'test.ignore'), 'hello');
-          fs.writeFile(path.join(ignoreGlobDir, 'erongi', 'test.txt'), 'hello');
-          fs.writeFile(path.join(ignoreGlobDir, 'erongi', 'deep', 'test.txt'), 'hello');
-
-          let res = await nextEvent();
-          assert.deepEqual(res, [
-            {type: 'create', path: path.join(ignoreGlobDir, 'test.txt')},
-          ]);
-        });
-      });
-
-      describe('multiple', () => {
+      describe.skip('multiple', () => {
         it('should support multiple watchers for the same directory', async () => {
           let dir = path.join(
             fs.realpathSync(require('os').tmpdir()),
@@ -848,6 +810,44 @@ describe('watcher', () => {
           assert.deepEqual(res, [{type: 'create', path: f}]);
 
           await worker.terminate();
+        });
+      });
+
+      describe('ignore', () => {
+        it('should ignore a directory', async () => {
+          let f1 = getFilename();
+          let f2 = getFilename(path.basename(ignoreDir));
+          await fs.mkdir(ignoreDir);
+
+          fs.writeFile(f1, 'hello');
+          fs.writeFile(f2, 'sup');
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [{type: 'create', path: f1}]);
+        });
+
+        it('should ignore a file', async () => {
+          let f1 = getFilename();
+
+          fs.writeFile(f1, 'hello');
+          fs.writeFile(ignoreFile, 'sup');
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [{type: 'create', path: f1}]);
+        });
+
+        it('should ignore globs', async () => {
+          fs.writeFile(path.join(ignoreGlobDir, 'test.txt'), 'hello');
+          fs.writeFile(path.join(ignoreGlobDir, 'test.ignore'), 'hello');
+          fs.writeFile(path.join(ignoreGlobDir, 'ignore', 'test.txt'), 'hello');
+          fs.writeFile(path.join(ignoreGlobDir, 'ignore', 'test.ignore'), 'hello');
+          fs.writeFile(path.join(ignoreGlobDir, 'erongi', 'test.txt'), 'hello');
+          fs.writeFile(path.join(ignoreGlobDir, 'erongi', 'deep', 'test.txt'), 'hello');
+
+          let res = await nextEvent();
+          assert.deepEqual(res, [
+            {type: 'create', path: path.join(ignoreGlobDir, 'test.txt')},
+          ]);
         });
       });
     });

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -79,7 +79,7 @@ describe('watcher', () => {
       });
 
       describe('files', () => {
-        it('should emit when a file is created', async () => {
+        it.only('should emit when a file is created', async () => {
           let f = getFilename();
           fs.writeFile(f, 'hello world');
           let res = await nextEvent();

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -79,7 +79,7 @@ describe('watcher', () => {
       });
 
       describe('files', () => {
-        it.only('should emit when a file is created', async () => {
+        it('should emit when a file is created', async () => {
           let f = getFilename();
           fs.writeFile(f, 'hello world');
           let res = await nextEvent();
@@ -821,6 +821,8 @@ describe('watcher', () => {
         fs.writeFile(f, 'hello world');
         let [res] = await Promise.all([nextEvent(), workerPromise]);
         assert.deepEqual(res, [{type: 'create', path: f}]);
+
+        await worker.terminate();
       });
     });
   });

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -791,7 +791,7 @@ describe('watcher', () => {
         });
       });
 
-      describe('workers', () => {
+      describe('worker threads', () => {
         it('should support worker threads', async function () {
           let worker = new Worker(`
             const {parentPort} = require('worker_threads');


### PR DESCRIPTION
This will enable the watcher to be used from multiple node worker threads. It also removes the last remaining direct usage of libuv, which should enable other implementations such as Deno and Bun to potentially work (I have not tested this). Fixes #96. The code is actually quite a bit simpler and more straightforward to understand now too by passing data to the callback directly rather than storing it in the watcher instance and needing a bunch of extra locks.