### PR TITLE
Include C++ sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "index.d.ts",
     "wrapper.js",
     "package.json",
-    "README.md"
+    "README.md",
+    "binding.gyp",
+    "src"
   ],
   "scripts": {
     "prebuild": "prebuildify --napi --strip --tag-libc",


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/watcher/issues/156

I can't actually reproduce that case where the prebuilds are being used correctly though, [might be related to that npm bug](https://github.com/npm/cli/issues/4828)