### PR TITLE
Try to make writeSnapshot atomic for watchman backend

### DIFF
--- a/src/watchman/WatchmanBackend.cc
+++ b/src/watchman/WatchmanBackend.cc
@@ -1,6 +1,7 @@
 #include <string>
 #include <fstream>
 #include <stdlib.h>
+#include <filesystem>
 #include <algorithm>
 #include "../DirTree.hh"
 #include "../Event.hh"
@@ -241,8 +242,14 @@ void WatchmanBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath)
   std::unique_lock<std::mutex> lock(mMutex);
   watchmanWatch(watcher.mDir);
 
-  std::ofstream ofs(*snapshotPath);
-  ofs << clock(watcher);
+  auto clockValue = clock(watcher);
+  auto temporaryDirectory = std::filesystem::temp_directory_path();
+  auto temporaryFilePath = temporaryDirectory.append("tmp-parcel-snapshot.txt");
+  {
+    std::ofstream ofs(temporaryFilePath);
+    ofs << clockValue;
+  }
+  std::filesystem::rename(temporaryFilePath, *snapshotPath);
 }
 
 void WatchmanBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath) {


### PR DESCRIPTION
This change aims to prevent snapshot files from being corrupted if the process is killed while it is being written.