### PR TITLE
Fix use after free errors

### DIFF
--- a/src/Backend.cc
+++ b/src/Backend.cc
@@ -138,13 +138,13 @@ Backend::~Backend() {
   #endif
 }
 
-void Backend::watch(Watcher &watcher) {
+void Backend::watch(WatcherRef watcher) {
   std::unique_lock<std::mutex> lock(mMutex);
-  auto res = mSubscriptions.find(&watcher);
+  auto res = mSubscriptions.find(watcher);
   if (res == mSubscriptions.end()) {
     try {
       this->subscribe(watcher);
-      mSubscriptions.insert(&watcher);
+      mSubscriptions.insert(watcher);
     } catch (std::exception &err) {
       unref();
       throw;
@@ -152,9 +152,9 @@ void Backend::watch(Watcher &watcher) {
   }
 }
 
-void Backend::unwatch(Watcher &watcher) {
+void Backend::unwatch(WatcherRef watcher) {
   std::unique_lock<std::mutex> lock(mMutex);
-  size_t deleted = mSubscriptions.erase(&watcher);
+  size_t deleted = mSubscriptions.erase(watcher);
   if (deleted > 0) {
     this->unsubscribe(watcher);
     unref();
@@ -168,7 +168,7 @@ void Backend::unref() {
 }
 
 void Backend::handleWatcherError(WatcherError &err) {
-  unwatch(*err.mWatcher);
+  unwatch(err.mWatcher);
   err.mWatcher->notifyError(err);
 }
 

--- a/src/Backend.hh
+++ b/src/Backend.hh
@@ -13,22 +13,22 @@ public:
   void notifyStarted();
 
   virtual void start();
-  virtual void writeSnapshot(Watcher &watcher, std::string *snapshotPath) = 0;
-  virtual void getEventsSince(Watcher &watcher, std::string *snapshotPath) = 0;
-  virtual void subscribe(Watcher &watcher) = 0;
-  virtual void unsubscribe(Watcher &watcher) = 0;
+  virtual void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) = 0;
+  virtual void getEventsSince(WatcherRef watcher, std::string *snapshotPath) = 0;
+  virtual void subscribe(WatcherRef watcher) = 0;
+  virtual void unsubscribe(WatcherRef watcher) = 0;
 
   static std::shared_ptr<Backend> getShared(std::string backend);
 
-  void watch(Watcher &watcher);
-  void unwatch(Watcher &watcher);
+  void watch(WatcherRef watcher);
+  void unwatch(WatcherRef watcher);
   void unref();
   void handleWatcherError(WatcherError &err);
 
   std::mutex mMutex;
   std::thread mThread;
 private:
-  std::unordered_set<Watcher *> mSubscriptions;
+  std::unordered_set<WatcherRef> mSubscriptions;
   Signal mStartedSignal;
 
   void handleError(std::exception &err);

--- a/src/Watcher.cc
+++ b/src/Watcher.cc
@@ -4,21 +4,21 @@
 using namespace Napi;
 
 struct WatcherHash {
-  std::size_t operator() (std::shared_ptr<Watcher> const &k) const {
+  std::size_t operator() (WatcherRef const &k) const {
     return std::hash<std::string>()(k->mDir);
   }
 };
 
 struct WatcherCompare {
-  size_t operator() (std::shared_ptr<Watcher> const &a, std::shared_ptr<Watcher> const &b) const {
+  size_t operator() (WatcherRef const &a, WatcherRef const &b) const {
     return *a == *b;
   }
 };
 
-static std::unordered_set<std::shared_ptr<Watcher>, WatcherHash, WatcherCompare> sharedWatchers;
+static std::unordered_set<WatcherRef , WatcherHash, WatcherCompare> sharedWatchers;
 
-std::shared_ptr<Watcher> Watcher::getShared(std::string dir, std::unordered_set<std::string> ignorePaths, std::unordered_set<Glob> ignoreGlobs) {
-  std::shared_ptr<Watcher> watcher = std::make_shared<Watcher>(dir, ignorePaths, ignoreGlobs);
+WatcherRef Watcher::getShared(std::string dir, std::unordered_set<std::string> ignorePaths, std::unordered_set<Glob> ignoreGlobs) {
+  WatcherRef watcher = std::make_shared<Watcher>(dir, ignorePaths, ignoreGlobs);
   auto found = sharedWatchers.find(watcher);
   if (found != sharedWatchers.end()) {
     return *found;

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -79,11 +79,11 @@ public:
   }
 private:
   std::shared_ptr<Backend> backend;
-  std::shared_ptr<Watcher> watcher;
+  WatcherRef watcher;
   std::string snapshotPath;
 
   void execute() override {
-    backend->writeSnapshot(*watcher, &snapshotPath);
+    backend->writeSnapshot(watcher, &snapshotPath);
   }
 };
 
@@ -107,11 +107,11 @@ public:
   }
 private:
   std::shared_ptr<Backend> backend;
-  std::shared_ptr<Watcher> watcher;
+  WatcherRef watcher;
   std::string snapshotPath;
 
   void execute() override {
-    backend->getEventsSince(*watcher, &snapshotPath);
+    backend->getEventsSince(watcher, &snapshotPath);
   }
 
   Value getResult() override {
@@ -169,13 +169,13 @@ public:
   }
 
 private:
-  std::shared_ptr<Watcher> watcher;
+  WatcherRef watcher;
   std::shared_ptr<Backend> backend;
   FunctionReference callback;
 
   void execute() override {
     try {
-      backend->watch(*watcher);
+      backend->watch(watcher);
     } catch (std::exception &err) {
       watcher->destroy();
       throw;
@@ -197,13 +197,13 @@ public:
   }
 
 private:
-  std::shared_ptr<Watcher> watcher;
+  WatcherRef watcher;
   std::shared_ptr<Backend> backend;
   bool shouldUnwatch;
 
   void execute() override {
     if (shouldUnwatch) {
-      backend->unwatch(*watcher);
+      backend->unwatch(watcher);
     }
   }
 };

--- a/src/kqueue/KqueueBackend.hh
+++ b/src/kqueue/KqueueBackend.hh
@@ -8,7 +8,7 @@
 #include "../Signal.hh"
 
 struct KqueueSubscription {
-  Watcher *watcher;
+  WatcherRef watcher;
   std::string path;
   std::shared_ptr<DirTree> tree;
   int fd;
@@ -18,8 +18,8 @@ class KqueueBackend : public BruteForceBackend {
 public:
   void start() override;
   ~KqueueBackend();
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
 private:
   int mKqueue;
   int mPipe[2];
@@ -27,8 +27,8 @@ private:
   std::unordered_map<int, DirEntry *> mFdToEntry;
   Signal mEndedSignal;
 
-  bool watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree);
-  bool compareDir(int fd, std::string &dir, std::unordered_set<Watcher *> &watchers);
+  bool watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree);
+  bool compareDir(int fd, std::string &dir, std::unordered_set<WatcherRef> &watchers);
   std::vector<KqueueSubscription *> findSubscriptions(std::string &path);
 };
 

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -64,7 +64,7 @@ InotifyBackend::~InotifyBackend() {
 }
 
 // This function is called by Backend::watch which takes a lock on mMutex
-void InotifyBackend::subscribe(Watcher &watcher) {
+void InotifyBackend::subscribe(WatcherRef watcher) {
   // Build a full directory tree recursively, and watch each directory.
   std::shared_ptr<DirTree> tree = getTree(watcher);
 
@@ -78,7 +78,7 @@ void InotifyBackend::subscribe(Watcher &watcher) {
   }
 }
 
-bool InotifyBackend::watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree) {
+bool InotifyBackend::watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree) {
   int wd = inotify_add_watch(mInotify, path.c_str(), INOTIFY_MASK);
   if (wd == -1) {
     return false;
@@ -213,7 +213,7 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
 }
 
 // This function is called by Backend::unwatch which takes a lock on mMutex
-void InotifyBackend::unsubscribe(Watcher &watcher) {
+void InotifyBackend::unsubscribe(WatcherRef watcher) {
   // Find any subscriptions pointing to this watcher, and remove them.
   for (auto it = mSubscriptions.begin(); it != mSubscriptions.end();) {
     if (it->second->watcher == &watcher) {

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -72,7 +72,7 @@ void InotifyBackend::subscribe(WatcherRef watcher) {
     if (it->second.isDir) {
       bool success = watchDir(watcher, it->second.path, tree);
       if (!success) {
-        throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + strerror(errno), &watcher);
+        throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + strerror(errno), watcher);
       }
     }
   }
@@ -87,7 +87,7 @@ bool InotifyBackend::watchDir(WatcherRef watcher, std::string path, std::shared_
   std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>();
   sub->tree = tree;
   sub->path = path;
-  sub->watcher = &watcher;
+  sub->watcher = watcher;
   mSubscriptions.emplace(wd, sub);
 
   return true;
@@ -98,7 +98,7 @@ void InotifyBackend::handleEvents() {
   struct inotify_event *event;
 
   // Track all of the watchers that are touched so we can notify them at the end of the events.
-  std::unordered_set<Watcher *> watchers;
+  std::unordered_set<WatcherRef> watchers;
 
   while (true) {
     int n = read(mInotify, &buf, BUFFER_SIZE);
@@ -131,7 +131,7 @@ void InotifyBackend::handleEvents() {
   }
 }
 
-void InotifyBackend::handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers) {
+void InotifyBackend::handleEvent(struct inotify_event *event, std::unordered_set<WatcherRef> &watchers) {
   std::unique_lock<std::mutex> lock(mMutex);
 
   // Find the subscriptions for this watch descriptor
@@ -150,7 +150,7 @@ void InotifyBackend::handleEvent(struct inotify_event *event, std::unordered_set
 
 bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub) {
   // Build full path and check if its in our ignore list.
-  Watcher *watcher = sub->watcher;
+  std::shared_ptr<Watcher> watcher = sub->watcher;
   std::string path = std::string(sub->path);
   bool isDir = event->mask & IN_ISDIR;
 
@@ -174,7 +174,7 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
     DirEntry *entry = sub->tree->add(path, CONVERT_TIME(st.st_mtim), S_ISDIR(st.st_mode));
 
     if (entry->isDir) {
-      bool success = watchDir(*watcher, path, sub->tree);
+      bool success = watchDir(watcher, path, sub->tree);
       if (!success) {
         sub->tree->remove(path);
         return false;
@@ -216,11 +216,11 @@ bool InotifyBackend::handleSubscription(struct inotify_event *event, std::shared
 void InotifyBackend::unsubscribe(WatcherRef watcher) {
   // Find any subscriptions pointing to this watcher, and remove them.
   for (auto it = mSubscriptions.begin(); it != mSubscriptions.end();) {
-    if (it->second->watcher == &watcher) {
+    if (it->second->watcher.get() == watcher.get()) {
       if (mSubscriptions.count(it->first) == 1) {
         int err = inotify_rm_watch(mInotify, it->first);
         if (err == -1) {
-          throw WatcherError(std::string("Unable to remove watcher: ") + strerror(errno), &watcher);
+          throw WatcherError(std::string("Unable to remove watcher: ") + strerror(errno), watcher);
         }
       }
 

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -10,7 +10,7 @@
 struct InotifySubscription {
   std::shared_ptr<DirTree> tree;
   std::string path;
-  Watcher *watcher;
+  WatcherRef watcher;
 };
 
 class InotifyBackend : public BruteForceBackend {
@@ -27,7 +27,7 @@ private:
 
   bool watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree);
   void handleEvents();
-  void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
+  void handleEvent(struct inotify_event *event, std::unordered_set<WatcherRef> &watchers);
   bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);
 };
 

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -17,15 +17,15 @@ class InotifyBackend : public BruteForceBackend {
 public:
   void start() override;
   ~InotifyBackend();
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
 private:
   int mPipe[2];
   int mInotify;
   std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
   Signal mEndedSignal;
 
-  bool watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree);
+  bool watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree);
   void handleEvents();
   void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
   bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -38,7 +38,10 @@ bool pathExists(char *path) {
   return res;
 }
 
-struct State {
+class State: public WatcherState {
+public:
+  virtual ~State() override {}
+
   FSEventStreamRef stream;
   std::shared_ptr<DirTree> tree;
   uint64_t since;
@@ -53,9 +56,15 @@ void FSEventsCallback(
   const FSEventStreamEventId eventIds[]
 ) {
   char **paths = (char **)eventPaths;
-  Watcher *watcher = (Watcher *)clientCallBackInfo;
-  EventList *list = &watcher->mEvents;
-  State *state = (State *)watcher->state;
+  std::shared_ptr<Watcher>& watcher = *static_cast<std::shared_ptr<Watcher> *>(clientCallBackInfo);
+
+  EventList& list = watcher->mEvents;
+  if (watcher->state == nullptr) {
+      return;
+  }
+
+  auto stateGuard = watcher->state;
+  auto* state = static_cast<State*>(stateGuard.get());
   uint64_t since = state->since;
   bool deletedRoot = false;
 
@@ -94,10 +103,10 @@ void FSEventsCallback(
     // Handle unambiguous events first
     if (isCreated && !(isRemoved || isModified || isRenamed)) {
       state->tree->add(paths[i], 0, isDir);
-      list->create(paths[i]);
+      list.create(paths[i]);
     } else if (isRemoved && !(isCreated || isModified || isRenamed)) {
       state->tree->remove(paths[i]);
-      list->remove(paths[i]);
+      list.remove(paths[i]);
       if (paths[i] == watcher->mDir) {
         deletedRoot = true;
       }
@@ -125,7 +134,7 @@ void FSEventsCallback(
         state->tree->add(paths[i], mtime, S_ISDIR(file.st_mode));
       }
 
-      list->update(paths[i]);
+      list.update(paths[i]);
     } else {
       // If multiple flags were set, then we need to call `stat` to determine if the file really exists.
       // This helps disambiguate creates, updates, and deletes.
@@ -137,7 +146,7 @@ void FSEventsCallback(
         // we'd rather ignore this event completely). This will result in some extra delete events
         // being emitted for files we don't know about, but that is the best we can do.
         state->tree->remove(paths[i]);
-        list->remove(paths[i]);
+        list.remove(paths[i]);
         if (paths[i] == watcher->mDir) {
           deletedRoot = true;
         }
@@ -155,10 +164,10 @@ void FSEventsCallback(
       // Some mounted file systems report a creation time of 0/unix epoch which we special case.
       if (isModified && (entry || (ctime <= since && ctime != 0))) {
         state->tree->update(paths[i], mtime);
-        list->update(paths[i]);
+        list.update(paths[i]);
       } else {
         state->tree->add(paths[i], mtime, S_ISDIR(file.st_mode));
-        list->create(paths[i]);
+        list.create(paths[i]);
       }
     }
   }
@@ -169,28 +178,28 @@ void FSEventsCallback(
   if (deletedRoot) {
     stopStream((FSEventStreamRef)streamRef, CFRunLoopGetCurrent());
     delete state;
-    watcher->state = NULL;
+    watcher->state = nullptr;
   }
 }
 
-void checkWatcher(Watcher &watcher) {
+void checkWatcher(WatcherRef watcher) {
   struct stat file;
-  if (stat(watcher.mDir.c_str(), &file)) {
-    throw WatcherError(strerror(errno), &watcher);
+  if (stat(watcher->mDir.c_str(), &file)) {
+    throw WatcherError(strerror(errno), watcher);
   }
 
   if (!S_ISDIR(file.st_mode)) {
-    throw WatcherError(strerror(ENOTDIR), &watcher);
+    throw WatcherError(strerror(ENOTDIR), watcher);
   }
 }
 
-void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
+void FSEventsBackend::startStream(WatcherRef watcher, FSEventStreamEventId id) {
   checkWatcher(watcher);
 
   CFAbsoluteTime latency = 0.001;
   CFStringRef fileWatchPath = CFStringCreateWithCString(
     NULL,
-    watcher.mDir.c_str(),
+    watcher->mDir.c_str(),
     kCFStringEncodingUTF8
   );
 
@@ -201,7 +210,9 @@ void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
     NULL
   );
 
-  FSEventStreamContext callbackInfo {0, (void *)&watcher, nullptr, nullptr, nullptr};
+  // Make a watcher reference we can pass into the callback. This ensures bumped ref-count.
+  std::shared_ptr<Watcher>* callbackWatcher = new std::shared_ptr<Watcher> (watcher);
+  FSEventStreamContext callbackInfo {0, static_cast<void*> (callbackWatcher), nullptr, nullptr, nullptr};
   FSEventStreamRef stream = FSEventStreamCreate(
     NULL,
     &FSEventsCallback,
@@ -212,8 +223,8 @@ void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
     kFSEventStreamCreateFlagFileEvents
   );
 
-  CFMutableArrayRef exclusions = CFArrayCreateMutable(NULL, watcher.mIgnorePaths.size(), NULL);
-  for (auto it = watcher.mIgnorePaths.begin(); it != watcher.mIgnorePaths.end(); it++) {
+  CFMutableArrayRef exclusions = CFArrayCreateMutable(NULL, watcher->mIgnorePaths.size(), NULL);
+  for (auto it = watcher->mIgnorePaths.begin(); it != watcher->mIgnorePaths.end(); it++) {
     CFStringRef path = CFStringCreateWithCString(
       NULL,
       it->c_str(),
@@ -233,11 +244,12 @@ void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
 
   if (!started) {
     FSEventStreamRelease(stream);
-    throw WatcherError("Error starting FSEvents stream", &watcher);
+    throw WatcherError("Error starting FSEvents stream", watcher);
   }
 
-  State *s = (State *)watcher.state;
-  s->tree = std::make_shared<DirTree>(watcher.mDir);
+  auto stateGuard = watcher->state;
+  State* s = static_cast<State*>(stateGuard.get());
+  s->tree = std::make_shared<DirTree>(watcher->mDir);
   s->stream = stream;
 }
 
@@ -260,7 +272,7 @@ FSEventsBackend::~FSEventsBackend() {
   CFRelease(mRunLoop);
 }
 
-void FSEventsBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath) {
+void FSEventsBackend::writeSnapshot(WatcherRef watcher, std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   checkWatcher(watcher);
 
@@ -274,7 +286,7 @@ void FSEventsBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath)
   ofs << CONVERT_TIME(now);
 }
 
-void FSEventsBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath) {
+void FSEventsBackend::getEventsSince(WatcherRef watcher, std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   std::ifstream ifs(*snapshotPath);
   if (ifs.fail()) {
@@ -286,33 +298,31 @@ void FSEventsBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath
   ifs >> id;
   ifs >> since;
 
-  State *s = new State;
+  auto s = std::make_shared<State>();
   s->since = since;
-  watcher.state = (void *)s;
+  watcher->state = s;
 
   startStream(watcher, id);
-  watcher.wait();
+  watcher->wait();
   stopStream(s->stream, mRunLoop);
 
-  delete s;
-  watcher.state = NULL;
+  watcher->state = nullptr;
 }
 
 // This function is called by Backend::watch which takes a lock on mMutex
-void FSEventsBackend::subscribe(Watcher &watcher) {
-  State *s = new State;
+void FSEventsBackend::subscribe(WatcherRef watcher) {
+  auto s = std::make_shared<State>();
   s->since = 0;
-  watcher.state = (void *)s;
+  watcher->state = s;
   startStream(watcher, kFSEventStreamEventIdSinceNow);
 }
 
 // This function is called by Backend::unwatch which takes a lock on mMutex
-void FSEventsBackend::unsubscribe(Watcher &watcher) {
-  State *s = (State *)watcher.state;
-  if (s != NULL) {
+void FSEventsBackend::unsubscribe(WatcherRef watcher) {
+  auto stateGuard = watcher->state;
+  State* s = static_cast<State*>(stateGuard.get());
+  if (s != nullptr) {
     stopStream(s->stream, mRunLoop);
-
-    delete s;
-    watcher.state = NULL;
+    watcher->state = nullptr;
   }
 }

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -40,8 +40,6 @@ bool pathExists(char *path) {
 
 class State: public WatcherState {
 public:
-  virtual ~State() override {}
-
   FSEventStreamRef stream;
   std::shared_ptr<DirTree> tree;
   uint64_t since;
@@ -177,7 +175,6 @@ void FSEventsCallback(
   // Stop watching if the root directory was deleted.
   if (deletedRoot) {
     stopStream((FSEventStreamRef)streamRef, CFRunLoopGetCurrent());
-    delete state;
     watcher->state = nullptr;
   }
 }

--- a/src/macos/FSEventsBackend.hh
+++ b/src/macos/FSEventsBackend.hh
@@ -8,12 +8,12 @@ class FSEventsBackend : public Backend {
 public:
   void start() override;
   ~FSEventsBackend();
-  void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
-  void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
 private:
-  void startStream(Watcher &watcher, FSEventStreamEventId id);
+  void startStream(WatcherRef watcher, FSEventStreamEventId id);
   CFRunLoopRef mRunLoop;
 };
 

--- a/src/shared/BruteForceBackend.cc
+++ b/src/shared/BruteForceBackend.cc
@@ -3,8 +3,8 @@
 #include "../Event.hh"
 #include "./BruteForceBackend.hh"
 
-std::shared_ptr<DirTree> BruteForceBackend::getTree(Watcher &watcher, bool shouldRead) {
-  auto tree = DirTree::getCached(watcher.mDir);
+std::shared_ptr<DirTree> BruteForceBackend::getTree(WatcherRef watcher, bool shouldRead) {
+  auto tree = DirTree::getCached(watcher->mDir);
 
   // If the tree is not complete, read it if needed.
   if (!tree->isComplete && shouldRead) {
@@ -15,7 +15,7 @@ std::shared_ptr<DirTree> BruteForceBackend::getTree(Watcher &watcher, bool shoul
   return tree;
 }
 
-void BruteForceBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath) {
+void BruteForceBackend::writeSnapshot(WatcherRef watcher, std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   auto tree = getTree(watcher);
   FILE *f = fopen(snapshotPath->c_str(), "w");
@@ -27,15 +27,15 @@ void BruteForceBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPat
   fclose(f);
 }
 
-void BruteForceBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath) {
+void BruteForceBackend::getEventsSince(WatcherRef watcher, std::string *snapshotPath) {
   std::unique_lock<std::mutex> lock(mMutex);
   FILE *f = fopen(snapshotPath->c_str(), "r");
   if (!f) {
     throw std::runtime_error(std::string("Unable to open snapshot file: ") + strerror(errno));
   }
 
-  DirTree snapshot{watcher.mDir, f};
+  DirTree snapshot{watcher->mDir, f};
   auto now = getTree(watcher);
-  now->getChanges(&snapshot, watcher.mEvents);
+  now->getChanges(&snapshot, watcher->mEvents);
   fclose(f);
 }

--- a/src/shared/BruteForceBackend.hh
+++ b/src/shared/BruteForceBackend.hh
@@ -7,19 +7,19 @@
 
 class BruteForceBackend : public Backend {
 public:
-  void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
-  void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
-  void subscribe(Watcher &watcher) override {
+  void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void subscribe(WatcherRef watcher) override {
     throw "Brute force backend doesn't support subscriptions.";
   }
 
-  void unsubscribe(Watcher &watcher) override {
+  void unsubscribe(WatcherRef watcher) override {
     throw "Brute force backend doesn't support subscriptions.";
   }
 
-  std::shared_ptr<DirTree> getTree(Watcher &watcher, bool shouldRead = true);
+  std::shared_ptr<DirTree> getTree(WatcherRef watcher, bool shouldRead = true);
 private:
-  void readTree(Watcher &watcher, std::shared_ptr<DirTree> tree);
+  void readTree(WatcherRef watcher, std::shared_ptr<DirTree> tree);
 };
 
 #endif

--- a/src/unix/fts.cc
+++ b/src/unix/fts.cc
@@ -16,11 +16,11 @@
 #define st_mtim st_mtimespec
 #endif
 
-void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
-  char *paths[2] {(char *)watcher.mDir.c_str(), NULL};
+void BruteForceBackend::readTree(WatcherRef watcher, std::shared_ptr<DirTree> tree) {
+  char *paths[2] {(char *)watcher->mDir.c_str(), NULL};
   FTS *fts = fts_open(paths, FTS_NOCHDIR | FTS_PHYSICAL, NULL);
   if (!fts) {
-    throw WatcherError(strerror(errno), &watcher);
+    throw WatcherError(strerror(errno), watcher);
   }
 
   FTSENT *node;
@@ -29,15 +29,15 @@ void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree
   while ((node = fts_read(fts)) != NULL) {
     if (node->fts_errno) {
       fts_close(fts);
-      throw WatcherError(strerror(node->fts_errno), &watcher);
+      throw WatcherError(strerror(node->fts_errno), watcher);
     }
 
     if (isRoot && !(node->fts_info & FTS_D)) {
       fts_close(fts);
-      throw WatcherError(strerror(ENOTDIR), &watcher);
+      throw WatcherError(strerror(ENOTDIR), watcher);
     }
 
-    if (watcher.isIgnored(std::string(node->fts_path))) {
+    if (watcher->isIgnored(std::string(node->fts_path))) {
       fts_set(fts, node, FTS_SKIP);
       continue;
     }

--- a/src/unix/legacy.cc
+++ b/src/unix/legacy.cc
@@ -24,7 +24,7 @@
 #endif
 #define ISDOT(a) (a[0] == '.' && (!a[1] || (a[1] == '.' && !a[2])))
 
-void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const char *relative, int parent_fd, const std::string &dirname) {
+void iterateDir(WatcherRef watcher, const std::shared_ptr <DirTree> tree, const char *relative, int parent_fd, const std::string &dirname) {
     int open_flags = (O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
     int new_fd = openat(parent_fd, relative, open_flags);
     if (new_fd == -1) {
@@ -68,7 +68,7 @@ void iterateDir(Watcher &watcher, const std::shared_ptr <DirTree> tree, const ch
     }
 }
 
-void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr <DirTree> tree) {
+void BruteForceBackend::readTree(WatcherRef watcher, std::shared_ptr <DirTree> tree) {
     int fd = open(watcher.mDir.c_str(), O_RDONLY);
     if (fd) {
         iterateDir(watcher, tree, ".", fd, watcher.mDir);

--- a/src/unix/legacy.cc
+++ b/src/unix/legacy.cc
@@ -32,7 +32,7 @@ void iterateDir(WatcherRef watcher, const std::shared_ptr <DirTree> tree, const 
             return; // ignore insufficient permissions
         }
 
-        throw WatcherError(strerror(errno), &watcher);
+        throw WatcherError(strerror(errno), watcher);
     }
 
     struct stat rootAttributes;
@@ -45,7 +45,7 @@ void iterateDir(WatcherRef watcher, const std::shared_ptr <DirTree> tree, const 
 
             std::string fullPath = dirname + "/" + ent->d_name;
 
-            if (!watcher.isIgnored(fullPath)) {
+            if (!watcher->isIgnored(fullPath)) {
                 struct stat attrib;
                 fstatat(new_fd, ent->d_name, &attrib, AT_SYMLINK_NOFOLLOW);
                 bool isDir = ent->d_type == DT_DIR;
@@ -64,14 +64,14 @@ void iterateDir(WatcherRef watcher, const std::shared_ptr <DirTree> tree, const 
     }
 
     if (errno) {
-        throw WatcherError(strerror(errno), &watcher);
+        throw WatcherError(strerror(errno), watcher);
     }
 }
 
 void BruteForceBackend::readTree(WatcherRef watcher, std::shared_ptr <DirTree> tree) {
-    int fd = open(watcher.mDir.c_str(), O_RDONLY);
+    int fd = open(watcher->mDir.c_str(), O_RDONLY);
     if (fd) {
-        iterateDir(watcher, tree, ".", fd, watcher.mDir);
+        iterateDir(watcher, tree, ".", fd, watcher->mDir);
         close(fd);
     }
 }

--- a/src/wasm/WasmBackend.cc
+++ b/src/wasm/WasmBackend.cc
@@ -7,7 +7,7 @@ void WasmBackend::start() {
   notifyStarted();
 }
 
-void WasmBackend::subscribe(Watcher &watcher) {
+void WasmBackend::subscribe(WatcherRef watcher) {
   // Build a full directory tree recursively, and watch each directory.
   std::shared_ptr<DirTree> tree = getTree(watcher);
 
@@ -18,7 +18,7 @@ void WasmBackend::subscribe(Watcher &watcher) {
   }
 }
 
-void WasmBackend::watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree) {
+void WasmBackend::watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree) {
   int wd = wasm_backend_add_watch(path.c_str(), (void *)this);
   std::shared_ptr<WasmSubscription> sub = std::make_shared<WasmSubscription>();
   sub->tree = tree;
@@ -116,7 +116,7 @@ bool WasmBackend::handleSubscription(int type, char *filename, std::shared_ptr<W
   return true;
 }
 
-void WasmBackend::unsubscribe(Watcher &watcher) {
+void WasmBackend::unsubscribe(WatcherRef watcher) {
   // Find any subscriptions pointing to this watcher, and remove them.
   for (auto it = mSubscriptions.begin(); it != mSubscriptions.end();) {
     if (it->second->watcher == &watcher) {

--- a/src/wasm/WasmBackend.hh
+++ b/src/wasm/WasmBackend.hh
@@ -14,7 +14,7 @@ extern "C" {
 struct WasmSubscription {
   std::shared_ptr<DirTree> tree;
   std::string path;
-  Watcher *watcher;
+  WatcherRef watcher;
 };
 
 class WasmBackend : public BruteForceBackend {

--- a/src/wasm/WasmBackend.hh
+++ b/src/wasm/WasmBackend.hh
@@ -20,14 +20,14 @@ struct WasmSubscription {
 class WasmBackend : public BruteForceBackend {
 public:
   void start() override;
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
   void handleEvent(int wd, int type, char *filename);
 private:
   int mWasm;
   std::unordered_multimap<int, std::shared_ptr<WasmSubscription>> mSubscriptions;
 
-  void watchDir(Watcher &watcher, std::string path, std::shared_ptr<DirTree> tree);
+  void watchDir(WatcherRef watcher, std::string path, std::shared_ptr<DirTree> tree);
   bool handleSubscription(int type, char *filename, std::shared_ptr<WasmSubscription> sub);
 };
 

--- a/src/watchman/WatchmanBackend.cc
+++ b/src/watchman/WatchmanBackend.cc
@@ -269,7 +269,7 @@ void WatchmanBackend::getEventsSince(WatcherRef watcher, std::string *snapshotPa
 std::string getId(WatcherRef watcher) {
   std::ostringstream id;
   id << "parcel-";
-  id << (void *)&watcher;
+  id << static_cast<void*>(watcher.get());
   return id.str();
 }
 

--- a/src/watchman/WatchmanBackend.hh
+++ b/src/watchman/WatchmanBackend.hh
@@ -12,21 +12,21 @@ public:
   void start() override;
   WatchmanBackend() : mStopped(false) {};
   ~WatchmanBackend();
-  void writeSnapshot(Watcher &watcher, std::string *snapshotPath) override;
-  void getEventsSince(Watcher &watcher, std::string *snapshotPath) override;
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
 private:
   std::unique_ptr<IPC> mIPC;
   Signal mRequestSignal;
   Signal mResponseSignal;
   BSER::Object mResponse;
   std::string mError;
-  std::unordered_map<std::string, Watcher *> mSubscriptions;
+  std::unordered_map<std::string, WatcherRef> mSubscriptions;
   bool mStopped;
   Signal mEndedSignal;
 
-  std::string clock(Watcher &watcher);
+  std::string clock(WatcherRef watcher);
   void watchmanWatch(std::string dir);
   BSER::Object watchmanRequest(BSER cmd);
   void handleSubscription(BSER::Object obj);

--- a/src/windows/WindowsBackend.cc
+++ b/src/windows/WindowsBackend.cc
@@ -67,7 +67,7 @@ WindowsBackend::~WindowsBackend() {
   QueueUserAPC([](__in ULONG_PTR) {}, mThread.native_handle(), (ULONG_PTR)this);
 }
 
-class Subscription: WatcherState {
+class Subscription: public WatcherState {
 public:
   Subscription(WindowsBackend *backend, WatcherRef watcher, std::shared_ptr<DirTree> tree) {
     mRunning = true;

--- a/src/windows/WindowsBackend.cc
+++ b/src/windows/WindowsBackend.cc
@@ -9,7 +9,7 @@
 #define NETWORK_BUF_SIZE 64 * 1024
 #define CONVERT_TIME(ft) ULARGE_INTEGER{ft.dwLowDateTime, ft.dwHighDateTime}.QuadPart
 
-void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
+void BruteForceBackend::readTree(WatcherRef watcher, std::shared_ptr<DirTree> tree) {
   std::stack<std::string> directories;
 
   directories.push(watcher.mDir);
@@ -260,7 +260,7 @@ private:
 };
 
 // This function is called by Backend::watch which takes a lock on mMutex
-void WindowsBackend::subscribe(Watcher &watcher) {
+void WindowsBackend::subscribe(WatcherRef watcher) {
   // Create a subscription for this watcher
   Subscription *sub = new Subscription(this, &watcher, getTree(watcher, false));
   watcher.state = (void *)sub;
@@ -277,7 +277,7 @@ void WindowsBackend::subscribe(Watcher &watcher) {
 }
 
 // This function is called by Backend::unwatch which takes a lock on mMutex
-void WindowsBackend::unsubscribe(Watcher &watcher) {
+void WindowsBackend::unsubscribe(WatcherRef watcher) {
   Subscription *sub = (Subscription *)watcher.state;
   delete sub;
 }

--- a/src/windows/WindowsBackend.hh
+++ b/src/windows/WindowsBackend.hh
@@ -9,8 +9,8 @@ class WindowsBackend : public BruteForceBackend {
 public:
   void start() override;
   ~WindowsBackend();
-  void subscribe(Watcher &watcher) override;
-  void unsubscribe(Watcher &watcher) override;
+  void subscribe(WatcherRef watcher) override;
+  void unsubscribe(WatcherRef watcher) override;
 private:
   bool mRunning;
 };

--- a/test/since.js
+++ b/test/since.js
@@ -68,7 +68,7 @@ describe('since', () => {
 
       describe('files', () => {
         it('should emit when a file is created', async function () {
-          this.timeout(5000);
+          this.timeout(10000);
           let f = getFilename();
           await watcher.writeSnapshot(tmpDir, snapshotPath, {backend});
           if (isSecondPrecision) {

--- a/wasm/index.mjs
+++ b/wasm/index.mjs
@@ -156,7 +156,7 @@ const wasm_env = {
   emscripten_resize_heap() {
     return 0;
   },
-  abort() {},
+  _abort_js() {},
   wasm_backend_add_watch(filename, backend) {
     let path = env.getString(filename);
     let watch = fs.watch(path, {encoding: 'buffer'}, (eventType, filename) => {


### PR DESCRIPTION
Fixes a few cases where use after free could happen, and one where it can be easily reproduced.

When using the FSEvents back-end, both the `Watcher` and a `State` pointers are passed as part of the context parameter to a C style callback.

Both of these pointers may be free-ed before the callback is called before this commit.

After this commit, these two pointers, as well as all most others in the codebase are replaced with `shared_ptr`.

This is a lazy fix and goes against C++ core guidelines - "F.7". (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-smart)

A secondary pass would use reference counting only in the shared ownership cases. For most back-ends this shared ownership happens on: error types, subscription maps/sets and state structs. (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-owner)