### PR TITLE
Add a option to run getEventsSince and writeSnapshot as one atomic operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ All of the APIs in `@parcel/watcher` support the following options, which are pa
   - glob patterns match on relative paths from the root that is watched. No events will be emitted for matching paths.
 - `backend` - the name of an explicitly chosen backend to use. Allowed options are `"fs-events"`, `"watchman"`, `"inotify"`, `"kqueue"`, `"windows"`, or `"brute-force"` (only for querying). If the specified backend is not available on the current platform, the default backend will be used instead.
 
+The `getEventsSince` API supports one additional option.
+
+- `writeSnapshot` - whether to update existing snapshot or not. default to `false`.
+
 ## WASM
 
 The `@parcel/watcher-wasm` package can be used in place of `@parcel/watcher` on unsupported platforms. It relies on the Node `fs` module, so in non-Node environments such as browsers, an `fs` polyfill will be needed.

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace ParcelWatcher {
   export function getEventsSince(
     dir: FilePath,
     snapshot: FilePath,
-    opts?: Options
+    opts?: Options & { writeSnapshot?: boolean }
   ): Promise<Event[]>;
   export function subscribe(
     dir: FilePath,

--- a/index.js.flow
+++ b/index.js.flow
@@ -28,7 +28,7 @@ declare module.exports: {
   getEventsSince(
     dir: FilePath,
     snapshot: FilePath,
-    opts?: Options
+    opts?: Options & { writeSnapshot?: boolean }
   ): Promise<Array<Event>>,
   subscribe(
     dir: FilePath,

--- a/src/Backend.hh
+++ b/src/Backend.hh
@@ -14,7 +14,7 @@ public:
 
   virtual void start();
   virtual void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) = 0;
-  virtual void getEventsSince(WatcherRef watcher, std::string *snapshotPath) = 0;
+  virtual void getEventsSince(WatcherRef watcher, std::string *snapshotPath, bool writeSnapshot) = 0;
   virtual void subscribe(WatcherRef watcher) = 0;
   virtual void unsubscribe(WatcherRef watcher) = 0;
 

--- a/src/macos/FSEventsBackend.hh
+++ b/src/macos/FSEventsBackend.hh
@@ -9,7 +9,7 @@ public:
   void start() override;
   ~FSEventsBackend();
   void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
-  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath, bool writeSnapshot) override;
   void subscribe(WatcherRef watcher) override;
   void unsubscribe(WatcherRef watcher) override;
 private:

--- a/src/shared/BruteForceBackend.cc
+++ b/src/shared/BruteForceBackend.cc
@@ -27,7 +27,7 @@ void BruteForceBackend::writeSnapshot(WatcherRef watcher, std::string *snapshotP
   fclose(f);
 }
 
-void BruteForceBackend::getEventsSince(WatcherRef watcher, std::string *snapshotPath) {
+void BruteForceBackend::getEventsSince(WatcherRef watcher, std::string *snapshotPath, bool writeSnapshot) {
   std::unique_lock<std::mutex> lock(mMutex);
   FILE *f = fopen(snapshotPath->c_str(), "r");
   if (!f) {
@@ -38,4 +38,14 @@ void BruteForceBackend::getEventsSince(WatcherRef watcher, std::string *snapshot
   auto now = getTree(watcher);
   now->getChanges(&snapshot, watcher->mEvents);
   fclose(f);
+
+  if (writeSnapshot) {
+    FILE *f = fopen(snapshotPath->c_str(), "w");
+    if (!f) {
+      throw std::runtime_error(std::string("Unable to open snapshot file: ") + strerror(errno));
+    }
+
+    now->write(f);
+    fclose(f);
+  }
 }

--- a/src/shared/BruteForceBackend.hh
+++ b/src/shared/BruteForceBackend.hh
@@ -8,7 +8,7 @@
 class BruteForceBackend : public Backend {
 public:
   void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
-  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath, bool writeSnapshot) override;
   void subscribe(WatcherRef watcher) override {
     throw "Brute force backend doesn't support subscriptions.";
   }

--- a/src/watchman/WatchmanBackend.hh
+++ b/src/watchman/WatchmanBackend.hh
@@ -13,7 +13,7 @@ public:
   WatchmanBackend() : mStopped(false) {};
   ~WatchmanBackend();
   void writeSnapshot(WatcherRef watcher, std::string *snapshotPath) override;
-  void getEventsSince(WatcherRef watcher, std::string *snapshotPath) override;
+  void getEventsSince(WatcherRef watcher, std::string *snapshotPath, bool writeSnapshot) override;
   void subscribe(WatcherRef watcher) override;
   void unsubscribe(WatcherRef watcher) override;
 private:

--- a/test/since.js
+++ b/test/since.js
@@ -480,6 +480,31 @@ describe('since', () => {
         });
       });
 
+      describe('atomic operation', () => {
+        it('should get events and update snapshot in an atomic operation if requested', async () => {
+          let f = getFilename();
+          await watcher.writeSnapshot(tmpDir, snapshotPath, {backend});
+          if (isSecondPrecision) {
+            await sleep(1000);
+          }
+          await fs.writeFile(f, 'hello world');
+          await sleep();
+
+          let res = await watcher.getEventsSince(tmpDir, snapshotPath, {
+            backend,
+            writeSnapshot: true,
+          });
+          assert.deepEqual(res, [{type: 'create', path: f}]);
+
+          await fs.writeFile(f, 'hi');
+          await sleep();
+          res = await watcher.getEventsSince(tmpDir, snapshotPath, {
+            backend,
+          });
+          assert.deepEqual(res, [{type: 'update', path: f}]);
+        })
+      })
+
       describe('ignore', () => {
         it('should ignore a directory', async () => {
           let f1 = getFilename();


### PR DESCRIPTION
This PR makes it possible to run `getEventsSince` and `writeSnapshot` as single atomic operation to avoid possible race conditions like missing events or duplicated events.

---

If `getEventsSince` is called before `writeSnapshot`, events might be missing:

``` js
writeSnapshot(dir, snapshot1)
...
getEventsSince(dir, snapshot1)
/* Event here might be missing */
writeSnapshot(dir, snapshot2)
...
getEventsSince(dir, snapshot2)
```

If `writeSnapshot` is called before `getEventsSince`, events might get fired twice:

``` js
writeSnapshot(dir, snapshot1)
...
writeSnapshot(dir, snapshot2)
/* Event here might get fired twice */
getEventsSince(dir, snapshot1)
...
getEventsSince(dir, snapshot2)
```

---

With the new atomic "get and update" option, no events will be missing or duplicated:

``` js
writeSnapshot(dir, snapshot)
...
getEventsSince(dir, snapshot, { writeSnapshot: true })
...
getEventsSince(dir, snapshot, { writeSnapshot: true })
```