### PR TITLE
Add musl build for ARM7 platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
             image: ghcr.io/prebuild/linux-armv7:2.1.1
             node: 18
           - os: ubuntu-latest
+            arch: arm
+            libc: musl
+            image: ghcr.io/prebuild/linux-armv7l-musl:2.1.1
+            node: 18
+          - os: ubuntu-latest
             arch: arm64
             image: ghcr.io/prebuild/android-arm64:2.1.1
             node: 18

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -49,6 +49,11 @@ const triples = [
     libc: 'glibc'
   },
   {
+    platform: 'linux',
+    arch: 'arm',
+    libc: 'musl'
+  },
+  {
     platform: 'android',
     arch: 'arm64'
   },


### PR DESCRIPTION
There are musl builds for x86_64 and arm64 platforms, but not arm7 (32-bit). This is needed, for example, to run on musl-based systems like Alpine on 32-bit ARM platforms (like older Raspberry Pis).

It's possible this is undesirable or incompatible, but I thought that enabling the build would be a good first step!