### PR TITLE
fix: catch std:regex error

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -40,7 +40,11 @@ std::unordered_set<Glob> getIgnoreGlobs(Env env, Value opts) {
         Value item = items.Get(Number::New(env, i));
         if (item.IsString()) {
           auto key = item.As<String>().Utf8Value();
-          result.emplace(key);
+          try {
+            result.emplace(key);
+          } catch (const std::regex_error& e) {
+            Error::New(env, e.what()).ThrowAsJavaScriptException();
+          }
         }
       }
     }


### PR DESCRIPTION
fix this bug: https://github.com/parcel-bundler/watcher/issues/194