### PR TITLE
Handle large changes from FS Events better in getEventsSince

### DIFF
--- a/src/Event.hh
+++ b/src/Event.hh
@@ -70,11 +70,27 @@ public:
   void clear() {
     std::lock_guard<std::mutex> l(mMutex);
     mEvents.clear();
+    mError.reset();
+  }
+
+  void error(std::string err) {
+    if (!mError.has_value()) {
+      mError.emplace(err);
+    }
+  }
+
+  bool hasError() {
+    return mError.has_value();
+  }
+
+  std::string getError() {
+    return mError.value_or("");
   }
 
 private:
   mutable std::mutex mMutex;
   std::map<std::string, Event> mEvents;
+  std::optional<std::string> mError;
   Event *internalUpdate(std::string path) {
     auto found = mEvents.find(path);
     if (found == mEvents.end()) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -112,6 +112,9 @@ private:
 
   void execute() override {
     backend->getEventsSince(watcher, &snapshotPath);
+    if (watcher->mEvents.hasError()) {
+      throw std::runtime_error(watcher->mEvents.getError());
+    }
   }
 
   Value getResult() override {

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -78,6 +78,17 @@ void FSEventsCallback(
     bool isDone = (eventFlags[i] & kFSEventStreamEventFlagHistoryDone) == kFSEventStreamEventFlagHistoryDone;
     bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;
 
+
+    if (eventFlags[i] & kFSEventStreamEventFlagMustScanSubDirs) {
+      if (eventFlags[i] & kFSEventStreamEventFlagUserDropped) {
+        list.error("Events were dropped by the FSEvents client. File system must be re-scanned.");
+      } else if (eventFlags[i] & kFSEventStreamEventFlagKernelDropped) {
+        list.error("Events were dropped by the kernel. File system must be re-scanned.");
+      } else {
+        list.error("Too many events. File system must be re-scanned.");
+      }
+    }
+
     if (isDone) {
       watcher->notify();
       break;
@@ -171,7 +182,7 @@ void FSEventsCallback(
   }
 
   if (!since) {
-  watcher->notify();
+    watcher->notify();
   }
 
   // Stop watching if the root directory was deleted.

--- a/src/macos/FSEventsBackend.cc
+++ b/src/macos/FSEventsBackend.cc
@@ -170,7 +170,9 @@ void FSEventsCallback(
     }
   }
 
+  if (!since) {
   watcher->notify();
+  }
 
   // Stop watching if the root directory was deleted.
   if (deletedRoot) {


### PR DESCRIPTION
When switching branches, running a package manager, or otherwise changing a lot of files at once, and then restarting Parcel, sometimes the cache would not invalidate properly. This was because not all file system events were being returned by `getEventsSince`. It turns out that macOS will actually call the FS events callback multiple times, and deliver the events in batches rather than all at once. So we need to wait for the `kFSEventStreamEventFlagHistoryDone` flag to be delivered rather than stopping after the first callback.

Additionally, this handles the `kFSEventStreamEventFlagMustScanSubDirs` flag, which is delivered by macOS if there are too many events and some of them have been dropped, either by the kernel or the user-space client. In this case, we emit an error from the watch callback, or resolve the `getEventsSince` promise with an error. The application must assume that all files could have been modified, and ignore the cache in this case. Parcel already handles when `getEventsSince` errors by creating a fresh request tracker.