### PR TITLE
upgrade detect-libc for better compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const {createWrapper} = require('./wrapper');
 
 let name = `@parcel/watcher-${process.platform}-${process.arch}`;
 if (process.platform === 'linux') {
-  const { MUSL, family } = require('detect-libc');
+  const { MUSL, familySync } = require('detect-libc');
+  const family = familySync();
   if (family === MUSL) {
     name += '-musl';
   } else {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "dependencies": {
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.3",
     "is-glob": "^4.0.3",
     "micromatch": "^4.0.5",
     "node-addon-api": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,10 +425,10 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+detect-libc@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
+  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
 
 diff@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This upgrades the detect-libc version to latest version. This version has better compatibility with bun runtime.
