### PR TITLE
add freebsd arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,17 @@ jobs:
           path: prebuilds
 
   build-freebsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build FreeBSD
+      - name: Build FreeBSD ${{ matrix.arch }}
         uses: vmactions/freebsd-vm@v1
         with:
+          arch: ${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}
           usesh: true
           prepare: |
             pkg install -y -f curl node libnghttp2 npm yarn
@@ -100,7 +105,7 @@ jobs:
           run: |
             yarn --frozen-lockfile --ignore-scripts
             npm install node-gyp -g
-            yarn prebuild --arch x64 -t 18.0.0
+            yarn prebuild --arch ${{ matrix.arch }} -t 18.0.0
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,17 @@ jobs:
       - run: yarn test
 
   test-freebsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Test in FreeBSD
+      - name: Test in FreeBSD ${{ matrix.arch }}
         uses: vmactions/freebsd-vm@v1
         with:
+          arch: ${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}
           usesh: true
           prepare: |
             pkg install -y -f curl node libnghttp2 npm yarn

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -59,6 +59,10 @@ const triples = [
   },
   {
     platform: 'freebsd',
+    arch: 'arm'
+  },
+  {
+    platform: 'freebsd',
     arch: 'x64'
   }
 ];


### PR DESCRIPTION
This PR would allow us to have native arm64 support for tailwindcss4 on FreeBSD :mango: :rainbow: :lemon: 

- this builds, passes all tests *except* sometimes the [kqueue test](https://github.com/dch/watcher/actions/runs/15820259286/job/46389509908#step:3:2072)  fails (on virtual qemu-arm64-inside-amd64-inside-docker) in the github PR pipeline
- but this builds and passes all tests "natively" on FreeBSD arm64 hardware

Is there any way to relax the mocha test for this specific combo? I suspect the combined virtualisation layers get in the way.

```
## real hardware - native FreeBSD, native arm64
gyp info ok
Done in 130.76s.
yarn run v1.22.19
$ mocha


  watcher
    kqueue
      files
        ✔ should emit when a file is created
        ✔ should emit when a file is updated (101ms)
        ✔ should emit when a file is renamed (101ms)
        ✔ should emit when an existing file is renamed (51ms)
        ✔ should emit when a file is renamed only changing case (101ms)
        ✔ should emit when a file is deleted (101ms)
      directories
        ✔ should emit when a directory is created (51ms)
        ✔ should emit when a directory is renamed (100ms)
        ✔ should emit when an existing directory is renamed (50ms)
        ✔ should emit when a directory is deleted (102ms)
        ✔ should handle when the directory to watch is deleted (266ms)
      sub-files
        ✔ should emit when a sub-file is created (101ms)
        ✔ should emit when a sub-file is updated (152ms)
        ✔ should emit when a sub-file is renamed (151ms)
        ✔ should emit when a sub-file is deleted (151ms)
      sub-directories
        ✔ should emit when a sub-directory is created (101ms)
        ✔ should emit when a sub-directory is renamed (151ms)
        ✔ should emit when a sub-directory is deleted with files inside (152ms)
        ✔ should emit when a sub-directory is deleted with directories inside (201ms)
      symlinks
        ✔ should emit when a symlink is created (101ms)
        ✔ should emit when a symlink is updated (151ms)
        ✔ should emit when a symlink is renamed (151ms)
        ✔ should emit when a symlink is deleted (151ms)
        ✔ should not crash when a folder symlink is created (151ms)
      rapid changes
        ✔ should coalese create and update events (50ms)
        ✔ should coalese delete and create events into a single update event (100ms)
        ✔ should ignore files that are created and deleted rapidly (50ms)
        ✔ should coalese create and rename events (51ms)
        ✔ should coalese multiple rename events (51ms)
        ✔ should coalese multiple update events (101ms)
        ✔ should coalese update and delete events (101ms)
      multiple
        ✔ should support multiple watchers for the same directory (266ms)
        ✔ should support multiple watchers for the same directory with different ignore paths (265ms)
        ✔ should support multiple watchers for different directories (266ms)
        ✔ should work when getting events since a snapshot on an already watched directory (1448ms)
      errors
        ✔ should error if the watched directory does not exist
        ✔ should error if the watched path is not a directory
      worker threads
        ✔ should support worker threads (162ms)
      ignore
        ✔ should ignore a directory (51ms)
        ✔ should ignore a file (51ms)
        ✔ should ignore globs (51ms)


  41 passing (6s)

Done in 6.69s.
root@testy:/tmp/watcher # uname -a
FreeBSD testy.skunkwerks.at 14.3-RELEASE FreeBSD 15.0-CURRENT main-n277710-1776ba8de549 GENERIC arm64
```

```
### inside the github-induced turducken monstrosity
   gmake: Leaving directory '/home/runner/work/watcher/watcher/build'
  gyp info ok 
  Done in 628.71s.
  yarn run v1.22.19
  $ mocha
  
  
    watcher
      kqueue
        files
          ✔ should emit when a file is created
          ✔ should emit when a file is updated (109ms)
          ✔ should emit when a file is renamed (114ms)
          ✔ should emit when an existing file is renamed (56ms)
          ✔ should emit when a file is renamed only changing case (108ms)
          ✔ should emit when a file is deleted (108ms)
        directories
          ✔ should emit when a directory is created (58ms)
          ✔ should emit when a directory is renamed (109ms)
          ✔ should emit when an existing directory is renamed (55ms)
          ✔ should emit when a directory is deleted (117ms)
          ✔ should handle when the directory to watch is deleted (284ms)
        sub-files
          ✔ should emit when a sub-file is created (110ms)
          ✔ should emit when a sub-file is updated (167ms)
          ✔ should emit when a sub-file is renamed (167ms)
          ✔ should emit when a sub-file is deleted (159ms)
        sub-directories
          ✔ should emit when a sub-directory is created (107ms)
          ✔ should emit when a sub-directory is renamed (165ms)
          ✔ should emit when a sub-directory is deleted with files inside (169ms)
          ✔ should emit when a sub-directory is deleted with directories inside (218ms)
        symlinks
          ✔ should emit when a symlink is created (110ms)
          ✔ should emit when a symlink is updated (164ms)
          ✔ should emit when a symlink is renamed (160ms)
          ✔ should emit when a symlink is deleted (164ms)
          ✔ should not crash when a folder symlink is created (162ms)
        rapid changes
          ✔ should coalese create and update events (57ms)
          ✔ should coalese delete and create events into a single update event (108ms)
          1) should ignore files that are created and deleted rapidly
          ✔ should coalese create and rename events (57ms)
          ✔ should coalese multiple rename events (58ms)
          ✔ should coalese multiple update events (121ms)
          ✔ should coalese update and delete events (111ms)
        multiple
          ✔ should support multiple watchers for the same directory (280ms)
          ✔ should support multiple watchers for the same directory with different ignore paths (282ms)
          ✔ should support multiple watchers for different directories (279ms)
          ✔ should work when getting events since a snapshot on an already watched directory (1489ms)
        errors
          ✔ should error if the watched directory does not exist
          ✔ should error if the watched path is not a directory
        worker threads
          ✔ should support worker threads (575ms)
        ignore
          ✔ should ignore a directory (56ms)
          ✔ should ignore a file (55ms)
          ✔ should ignore globs (56ms)
  
  
    40 passing (7s)
    1 failing
  
    1) watcher
         kqueue
           rapid changes
             should ignore files that are created and deleted rapidly:
  
        AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:
  
  [
    {
      path: '/tmp/lhp9d524l3a/test477nhrfjmasih',
      type: 'create'
    },
    {
      path: '/tmp/lhp9d524l3a/test48307afuatqosc',
      type: 'create'
    }
  ]
  
  should loosely deep-equal
  
  [
    {
      path: '/tmp/lhp9d524l3a/test477nhrfjmasih',
      type: 'create'
    }
  ]
        + expected - actual
  
           {
             "path": "/tmp/lhp9d524l3a/test477nhrfjmasih"
             "type": "create"
           }
        -  {
        -    "path": "/tmp/lhp9d524l3a/test48307afuatqosc"
        -    "type": "create"
        -  }
         ]
        
        at Context.<anonymous> (test/watcher.js:518:20)
  
  
  
  error Command failed with exit code 1.
```