### PR TITLE
Reduce dependencies by switching to picomatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can specify the exact backend you wish to use by passing the `backend` optio
 
 All of the APIs in `@parcel/watcher` support the following options, which are passed as an object as the last function argument.
 
-- `ignore` - an array of paths or glob patterns to ignore. uses [`is-glob`](https://github.com/micromatch/is-glob) to distinguish paths from globs. glob patterns are parsed with [`micromatch`](https://github.com/micromatch/micromatch) (see [features](https://github.com/micromatch/micromatch#matching-features)).
+- `ignore` - an array of paths or glob patterns to ignore. uses [`is-glob`](https://github.com/micromatch/is-glob) to distinguish paths from globs. glob patterns are parsed with [`picomatch`](https://github.com/micromatch/picomatch) (see [features](https://github.com/micromatch/picomatch#globbing-features)).
   - paths can be relative or absolute and can either be files or directories. No events will be emitted about these files or directories or their children.
   - glob patterns match on relative paths from the root that is watched. No events will be emitted for matching paths.
 - `backend` - the name of an explicitly chosen backend to use. Allowed options are `"fs-events"`, `"watchman"`, `"inotify"`, `"kqueue"`, `"windows"`, or `"brute-force"` (only for querying). If the specified backend is not available on the current platform, the default backend will be used instead.

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "dependencies": {
     "detect-libc": "^1.0.3",
     "is-glob": "^4.0.3",
-    "micromatch": "^4.0.5",
-    "node-addon-api": "^7.0.0"
+    "node-addon-api": "^7.0.0",
+    "picomatch": "^4.0.3"
   },
   "devDependencies": {
     "esbuild": "^0.19.8",

--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -50,7 +50,7 @@ wasmPkg.files = ['*.js', '*.cjs', '*.mjs', '*.d.ts', '*.wasm'];
 wasmPkg.dependencies = {
   'napi-wasm': pkg.devDependencies['napi-wasm'],
   'is-glob': pkg.dependencies['is-glob'],
-  'micromatch': pkg.dependencies['micromatch']
+  'picomatch': pkg.dependencies['picomatch']
 };
 wasmPkg.exports = {
   types: './index.d.ts',

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const micromatch = require('micromatch');
+const picomatch = require('picomatch');
 const isGlob = require('is-glob');
 
 function normalizeOptions(dir, opts = {}) {
@@ -14,16 +14,12 @@ function normalizeOptions(dir, opts = {}) {
           opts.ignoreGlobs = [];
         }
 
-        const regex = micromatch.makeRe(value, {
+        const regex = picomatch.makeRe(value, {
           // We set `dot: true` to workaround an issue with the
           // regular expression on Linux where the resulting
           // negative lookahead `(?!(\\/|^)` was never matching
           // in some cases. See also https://bit.ly/3UZlQDm
-          dot: true,
-          // C++ does not support lookbehind regex patterns, they
-          // were only added later to JavaScript engines
-          // (https://bit.ly/3V7S6UL)
-          lookbehinds: false
+          dot: true
         });
         opts.ignoreGlobs.push(regex.source);
       } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,7 +243,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -848,14 +848,6 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-micromatch@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -1047,10 +1039,10 @@ picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This has a few advantages:
- Removed 5 dependencies and 3 maintainers from dependency tree to reduce supply chain risk and number of deprecation and security warnings
- `micromatch` is stuck back on `picomatch` version 2 whereas this lets us use the latest version

`picomatch` supports all the same exact syntax as `micromatch` except for ranges (e.g. `{01..03}`) and increments (e.g. `{2..10..2}`). I've switched tons 25m downloads/week worth of projects from `micromatch` to `picomatch` and have yet to run into a single person who has been using either of these globbing syntaxes.