### PR TITLE
Remove `D_FORTIFY_SOURCE` flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,6 @@
       "sources": [ "src/binding.cc", "src/Watcher.cc", "src/Backend.cc", "src/DirTree.cc", "src/Glob.cc", "src/Debounce.cc" ],
       "include_dirs" : ["<!(node -p \"require('node-addon-api').include_dir\")"],
       'cflags!': [ '-fno-exceptions', '-std=c++17' ],
-      'cflags': ['-O2', '-D_FORTIFY_SOURCE=2'],
       'cflags_cc!': [ '-fno-exceptions', '-std=c++17' ],
       "conditions": [
         ['OS=="mac"', {


### PR DESCRIPTION
This flag is causing build issues on Linux at least in VS Code environments, see https://github.com/microsoft/vscode/actions/runs/20807797454/job/59765414369?pr=286484

As this change was contributed for VS Code, I am taking the freedom to remove the `D_FORTIFY_SOURCE` flag again that causes this.

This is a partial revert of https://github.com/parcel-bundler/watcher/pull/219

//cc @rzhao271 