### PR TITLE
eng - try to fix release script to publish new NPM version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,6 @@ jobs:
     steps:
       - run: microdnf install git tar -y
         if: ${{ matrix.arch == 'x64' && matrix.libc == 'glibc' }}
-      - run: microdnf install git -y
-        if: ${{ matrix.arch == 'x64' && matrix.libc == 'glibc' }}
       - uses: actions/checkout@v6
       - run: corepack enable
       - uses: actions/setup-node@v6


### PR DESCRIPTION
ℹ️ trying to get out a new release to NPM but having trouble with the release script not working anymore. I am in talks with @devongovett to get this resolved and then should be able to publish a newer version.

The latest version is still `v2.5.1` until this is resolved.