### PR TITLE
chore: add static cast for ia32

### DIFF
--- a/src/watchman/BSER.cc
+++ b/src/watchman/BSER.cc
@@ -118,7 +118,7 @@ public:
   BSERString(std::istream &iss) {
     expectType(iss, BSER_STRING);
     int64_t len = BSERInteger(iss).intValue();
-    value.resize(len);
+    value.resize(static_cast<std::string::size_type>(len));
     iss.read(&value[0], len);
   }
 


### PR DESCRIPTION
Fixes the following conversion warning from https://github.com/parcel-bundler/watcher/actions/runs/21023395666/job/60444413082 :

D:\a\watcher\watcher\src\watchman\BSER.cc(121,18): error C4244: 'argument': conversion from 'int64_t' to 'const unsigned int', possible loss of data [D:\a\watcher\watcher\build\watcher.vcxproj]