### PR TITLE
Replace picomatch with glob-to-regexp to avoid pathological regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "detect-libc": "^2.0.3",
     "is-glob": "^4.0.3",
     "node-addon-api": "^7.0.0",
+    "glob-to-regexp": "^0.4.1",
     "picomatch": "^4.0.3"
   },
   "devDependencies": {

--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -50,6 +50,7 @@ wasmPkg.files = ['*.js', '*.cjs', '*.mjs', '*.d.ts', '*.wasm'];
 wasmPkg.dependencies = {
   'napi-wasm': pkg.devDependencies['napi-wasm'],
   'is-glob': pkg.dependencies['is-glob'],
+  'glob-to-regexp': pkg.dependencies['glob-to-regexp'],
   'picomatch': pkg.dependencies['picomatch']
 };
 wasmPkg.exports = {

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,6 +1,23 @@
 const path = require('path');
-const picomatch = require('picomatch');
+const globToRegExp = require('glob-to-regexp');
 const isGlob = require('is-glob');
+
+// Patterns containing extglob syntax that glob-to-regexp doesn't support
+const NEEDS_PICOMATCH = /[{(|)}\[\]!@+]/;
+let picomatch;
+
+function globToRegex(value) {
+  if (NEEDS_PICOMATCH.test(value)) {
+    if (!picomatch) {
+      picomatch = require('picomatch');
+    }
+    return picomatch.makeRe(value, {
+      dot: true,
+      windows: process.platform === 'win32',
+    });
+  }
+  return globToRegExp(value, { globstar: true });
+}
 
 function normalizeOptions(dir, opts = {}) {
   const { ignore, ...rest } = opts;
@@ -14,14 +31,7 @@ function normalizeOptions(dir, opts = {}) {
           opts.ignoreGlobs = [];
         }
 
-        const regex = picomatch.makeRe(value, {
-          // We set `dot: true` to workaround an issue with the
-          // regular expression on Linux where the resulting
-          // negative lookahead `(?!(\\/|^)` was never matching
-          // in some cases. See also https://bit.ly/3UZlQDm
-          dot: true,
-          windows: process.platform === 'win32',
-        });
+        const regex = globToRegex(value);
         opts.ignoreGlobs.push(regex.source);
       } else {
         if (!opts.ignorePaths) {


### PR DESCRIPTION
Hey! I ran into a perf issue on a large monorepo (~650K files) where `subscribe()` was taking ~120s. Profiled it and found that nearly all the time was spent in `std::regex_match()` in `Glob.cc`.

The root cause is that `picomatch.makeRe()` generates regex with nested negative lookaheads like `(?!(?:^|\/)\.{1,2}(?:\/|$))` — these exist to prevent `**` from matching `.`/`..` components, but real paths from `fts_read()` never contain those anyway. The lookaheads are pathological for libstdc++'s backtracking `std::regex`.

This PR uses `glob-to-regexp` instead, which generates lookahead-free regex. However, `glob-to-regexp` doesn't support extglob features like `(a|b)` alternation, `{a,b}` brace expansion, or `[a-e]` character classes in glob syntax. So this falls back to `picomatch` (lazily loaded) when the pattern contains those characters.

In practice, the common patterns (`**/node_modules/**`, `**/.git/**`, etc.) all go through `glob-to-regexp` — the picomatch fallback only kicks in for advanced patterns.

| Setup | `subscribe()` time |
|---|---|
| picomatch only (before) | **120s** |
| glob-to-regexp + picomatch fallback (after) | **17s** |

All 139 existing tests pass.

Fixes #244
