### PR TITLE
fix: Reject subscribe promise when inotify backend fails to start

### DIFF
--- a/src/Backend.cc
+++ b/src/Backend.cc
@@ -104,6 +104,12 @@ void Backend::run() {
       try {
         start();
       } catch (std::exception &err) {
+        // If start() throws before reaching notifyStarted() (e.g. inotify_init1
+        // fails with EMFILE), the main thread would otherwise block forever on
+        // mStartedSignal. Record the error, then unblock run() so subsequent
+        // watch() calls can surface the failure to the subscriber.
+        mStartError = err.what();
+        notifyStarted();
         handleError(err);
       }
     });
@@ -115,6 +121,7 @@ void Backend::run() {
     try {
       start();
     } catch (std::exception &err) {
+      mStartError = err.what();
       handleError(err);
     }
   #endif
@@ -144,6 +151,12 @@ Backend::~Backend() {
 
 void Backend::watch(WatcherRef watcher) {
   std::unique_lock<std::mutex> lock(mMutex);
+  if (mStartError) {
+    // Backend thread failed to start (e.g. EMFILE from inotify_init1).
+    // SubscribeRunner::execute() catches this and routes it into the
+    // returned Promise's reject path via PromiseRunner's error buffer.
+    throw std::runtime_error(*mStartError);
+  }
   auto res = mSubscriptions.find(watcher);
   if (res == mSubscriptions.end()) {
     try {

--- a/src/Backend.hh
+++ b/src/Backend.hh
@@ -4,6 +4,8 @@
 #include "Event.hh"
 #include "Watcher.hh"
 #include "Signal.hh"
+#include <optional>
+#include <string>
 #include <thread>
 
 class Backend {
@@ -30,6 +32,7 @@ public:
 private:
   std::unordered_set<WatcherRef> mSubscriptions;
   Signal mStartedSignal;
+  std::optional<std::string> mStartError;
 
   void handleError(std::exception &err);
 };


### PR DESCRIPTION
Previously, if `start()` threw before reaching `notifyStarted()` (e.g. `inotify_init1` returning `EMFILE` when `fs.inotify.max_user_instances` is exhausted), `Backend::run()` would block forever on `mStartedSignal`. The JS event loop was stuck inside the native call, so user-land timeouts and `AbortSignals `couldn't help either.

Now the thread's catch block records the error on the backend and signals started so `run()` returns. `Backend::watch()` checks the recorded error and throws, which `SubscribeRunner::execute()` already catches and routes into the returned Promise's reject path via `PromiseRunner`.

Minimal repro (with `fs.inotify.max_user_instances` temporarily lowered):

```ts
  const {subscribe} = require('@parcel/watcher')
  for (let i = 0; i < 100; i++) fs.watch(os.tmpdir(), () => {})
  await subscribe(os.tmpdir(), () => {})   // previously hung forever
```