### PR TITLE
feat: support RegExp ignores

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace ParcelWatcher {
     | 'brute-force';
   export type EventType = 'create' | 'update' | 'delete';
   export interface Options {
-    ignore?: (FilePath|GlobPattern)[];
+    ignore?: (FilePath|GlobPattern|RegExp)[];
     backend?: BackendType;
   }
   export type SubscribeCallback = (

--- a/index.js.flow
+++ b/index.js.flow
@@ -10,7 +10,7 @@ export type BackendType =
   | 'brute-force';
 export type EventType = 'create' | 'update' | 'delete';
 export interface Options {
-  ignore?: Array<FilePath | GlobPattern>,
+  ignore?: Array<FilePath | GlobPattern | RegExp>,
   backend?: BackendType
 }
 export type SubscribeCallback = (

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -901,12 +901,14 @@ describe('watcher', () => {
           let sub = await watcher.subscribe(
             dir,
             (err, e) => events.push(...e),
-            {backend, ignore: [/.*\.ignore$/]},
+            {backend, ignore: [/.*\.ignore$/, /node_modules/]},
           );
 
           try {
+            fs.mkdirpSync(path.join(dir, 'node_modules', 'pkg'));
             fs.writeFile(path.join(dir, 'test.txt'), 'hello');
             fs.writeFile(path.join(dir, 'test.ignore'), 'hello');
+            fs.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'hello');
             await new Promise((resolve) => setTimeout(resolve, 500));
           } finally {
             await sub.unsubscribe();

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -885,6 +885,44 @@ describe('watcher', () => {
             {type: 'create', path: path.join(ignoreGlobDir, 'test.txt')},
           ]);
         });
+
+        it('should ignore regex patterns', async () => {
+          if (backend === 'wasm') {
+            return;
+          }
+          let dir = path.join(
+            fs.realpathSync(require('os').tmpdir()),
+            Math.random().toString(31).slice(2),
+          );
+          fs.mkdirpSync(dir);
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          let events = [];
+          let sub = await watcher.subscribe(
+            dir,
+            (err, e) => events.push(...e),
+            {backend, ignore: [/.*\.ignore$/]},
+          );
+
+          try {
+            fs.writeFile(path.join(dir, 'test.txt'), 'hello');
+            fs.writeFile(path.join(dir, 'test.ignore'), 'hello');
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          } finally {
+            await sub.unsubscribe();
+          }
+
+          assert.deepEqual(events, [
+            {type: 'create', path: path.join(dir, 'test.txt')},
+          ]);
+        });
+
+        it('should throw when a regex with flags is passed in ignore', () => {
+          assert.throws(
+            () => watcher.subscribe(tmpDir, () => {}, {backend, ignore: [/foo/i]}),
+            /Flags are not supported/,
+          );
+        });
       });
     });
   });

--- a/wrapper.js
+++ b/wrapper.js
@@ -18,7 +18,11 @@ function normalizeOptions(dir, opts = {}) {
         if (!opts.ignoreGlobs) {
           opts.ignoreGlobs = [];
         }
-        opts.ignoreGlobs.push(value.source);
+        // The native backend uses std::regex_match (full-string match), but
+        // callers expect JS .test() semantics (substring search). Wrapping the
+        // source in ^[\\s\\S]*(?:…)[\\s\\S]*$ achieves that. The (?:…) group
+        // isolates the source so leading/trailing | in the source stays contained.
+        opts.ignoreGlobs.push(`^[\\s\\S]*(?:${value.source})[\\s\\S]*$`);
       } else if (isGlob(value)) {
         if (!opts.ignoreGlobs) {
           opts.ignoreGlobs = [];

--- a/wrapper.js
+++ b/wrapper.js
@@ -9,7 +9,17 @@ function normalizeOptions(dir, opts = {}) {
     opts = { ...rest };
 
     for (const value of ignore) {
-      if (isGlob(value)) {
+      if (value instanceof RegExp) {
+        if (value.flags !== '') {
+          throw new Error(
+            `RegExp ignore patterns must not have flags (got /${value.source}/${value.flags}). Flags are not supported by the native matcher.`,
+          );
+        }
+        if (!opts.ignoreGlobs) {
+          opts.ignoreGlobs = [];
+        }
+        opts.ignoreGlobs.push(value.source);
+      } else if (isGlob(value)) {
         if (!opts.ignoreGlobs) {
           opts.ignoreGlobs = [];
         }


### PR DESCRIPTION
Allow `RegExp` instances in the `ignore` option

The `ignore` array previously accepted only strings (file paths or globs). This adds support for passing a `RegExp` directly, for cases where a glob can't express the desired pattern or the caller already has a regex.

**How it works:** `RegExp` values are checked before the `isGlob` branch in `normalizeOptions`. The `.source` is pushed into `ignoreGlobs`, which the native binding already consumes as regex source strings — so no C++ changes are needed.

**Flags:** The native matcher (`std::regex` on native, the JS engine on wasm) only receives the source string, so JS flags would be silently ignored. To avoid surprising behavior, passing a `RegExp` with any flags throws a clear error.

---

Plan is to use it in https://github.com/jestjs/jest/pull/16188 where I already have a regex that I try to convert into a glob, only for this library to turn it back into a regex 😅 