### PR TITLE
fix: use assert.rejects for async subscribe throw test

### DIFF
--- a/test/watcher.js
+++ b/test/watcher.js
@@ -919,9 +919,9 @@ describe('watcher', () => {
           ]);
         });
 
-        it('should throw when a regex with flags is passed in ignore', () => {
-          assert.throws(
-            () => watcher.subscribe(tmpDir, () => {}, {backend, ignore: [/foo/i]}),
+        it('should throw when a regex with flags is passed in ignore', async () => {
+          await assert.rejects(
+            watcher.subscribe(tmpDir, () => {}, {backend, ignore: [/foo/i]}),
             /Flags are not supported/,
           );
         });


### PR DESCRIPTION
https://github.com/parcel-bundler/watcher/pull/248#issuecomment-4845892503

Silly mistake 😅 