### PR TITLE
Fix wasm build: function table no longer exported since 2.5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ FLAGS := $(INCS_Debug) \
 	-DNAPI_HAS_THREADS=1 \
 	-sEXPORTED_FUNCTIONS="['_napi_register_wasm_v1', '_wasm_backend_event_handler', '_malloc', '_free', '_on_timeout']" \
 	-sERROR_ON_UNDEFINED_SYMBOLS=0 \
+	-sEXPORTED_RUNTIME_METHODS=wasmTable \
 	-s INITIAL_MEMORY=524288000
 
 build/node-headers.tar.gz:


### PR DESCRIPTION
The wasm builds published since 2.5.4 (including 2.5.6 and 2.6.0) don't work at all: `@parcel/watcher-wasm` throws during module registration, before any watcher API can be called.

```
TypeError: Cannot read properties of undefined (reading 'get')
    at Environment.createFunction (napi-wasm/index.js:239:24)
    at napi_create_function (napi-wasm/index.js:745:20)
```

napi-wasm resolves its callback table from `instance.exports.__indirect_function_table`, but the published `watcher.wasm` stopped exporting it somewhere between 2.5.1 and 2.5.4. Comparing the two binaries:

```
2.5.1  watcher.wasm: 11 exports, includes __indirect_function_table (table)
2.5.4+ watcher.wasm: 10 exports, no table
```

Nothing in the repo changed. The release workflow builds in the unpinned `emscripten/emsdk` image, and newer emscripten stopped exporting the function table unless something references it (its metadce pass strips it otherwise).

Adding `-sEXPORTED_RUNTIME_METHODS=wasmTable` makes the glue reference the table so it survives DCE. `-Wl,--export-table` alone isn't enough, since wasm-ld exports it and then metadce removes it again.

Might also be worth pinning the emsdk image version in the release workflow so toolchain upgrades can't silently change the artifact again, but I kept this PR to the one-line fix.
