### PR TITLE
Fix the mismatch inotify error messages from write(2)

### DIFF
--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -22,7 +22,12 @@ void InotifyBackend::start() {
   // Init inotify file descriptor.
   mInotify = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
   if (mInotify == -1) {
-    throw std::runtime_error(std::string("Unable to initialize inotify: ") + strerror(errno));
+    // EMFILE from inotify_init1 means the fs.inotify.max_user_instances limit
+    // was reached, not the process open file limit that strerror's text suggests.
+    std::string reason = errno == EMFILE
+      ? "too many inotify instances (increase fs.inotify.max_user_instances) or open files"
+      : strerror(errno);
+    throw std::runtime_error(std::string("Unable to initialize inotify: ") + reason);
   }
 
   pollfd pollfds[2];
@@ -72,7 +77,12 @@ void InotifyBackend::subscribe(WatcherRef watcher) {
     if (it->second.isDir) {
       bool success = watchDir(watcher, it->second.path, tree);
       if (!success) {
-        throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + strerror(errno), watcher);
+        // ENOSPC from inotify_add_watch means the fs.inotify.max_user_watches limit
+        // was reached, not that the disk is full, so don't report strerror's misleading text.
+        std::string reason = errno == ENOSPC
+          ? "inotify watch limit reached (increase fs.inotify.max_user_watches)"
+          : strerror(errno);
+        throw WatcherError(std::string("inotify_add_watch on '") + it->second.path + std::string("' failed: ") + reason, watcher);
       }
     }
   }


### PR DESCRIPTION
The context is as following, in kibana, I noticed an error:
```
[watcher] fatal error  Error: inotify_add_watch on '/home/syscl/git/kibana/x-pack/solutions/security/test/security_solution_endpoint/apps' failed: No space left on device
error Command failed with exit code 1.
```
The real issue is the `Inotify Watches Limit` than the disk space(I have 88GiB of disk). So I took a look, the reason is that the error number returned by `inotify_add_watch` has a slightly different meaning for write(2) and inotify:
In Linux: https://github.com/torvalds/linux/blob/master/fs/notify/inotify/inotify_user.c#L602 `ENOSPC` indicates we hit the watch limit than the write(2)'s no disk space.

In brief, the misleading error message comes from the following:
1. inotify_add_watch relies on the https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno-base.h#L32C9-L32C15 for error code, `strerror` (belongs to glibc) returns the error message that is mainly for `write(2)`, as a result, the same error number, but slightly different meaning, e.g. ENOSPC means watch limit than no disk space. 
2. Same as the inotify_init1 -> EMFILE: strerror says "Too many open files", but it is usually fs.inotify.max_user_instances being reached.

This patch mainly address this mismatch, so that users will not look for the wrong place.